### PR TITLE
Enabling puppet purging on puppet controlled config folders

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -24,9 +24,12 @@ class mesos::master(
 ) inherits mesos {
 
   file { $conf_dir:
-    ensure => directory,
-    owner  => $owner,
-    group  => $group,
+    ensure  => directory,
+    owner   => $owner,
+    group   => $group,
+    recurse => true,
+    purge   => true,
+    force   => true,
   }
 
   file { $conf_file:

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -61,9 +61,12 @@ class mesos::slave (
   validate_hash($attributes)
 
   file { $conf_dir:
-    ensure => directory,
-    owner  => $owner,
-    group  => $group,
+    ensure  => directory,
+    owner   => $owner,
+    group   => $group,
+    recurse => true,
+    purge   => true,
+    force   => true,
   }
 
   file { "${conf_dir}/resources":
@@ -71,6 +74,8 @@ class mesos::slave (
     owner   => $owner,
     group   => $group,
     require => File[$conf_dir],
+    recurse => true,
+    purge   => true,
   }
 
   file { "${conf_dir}/attributes":
@@ -78,6 +83,8 @@ class mesos::slave (
     owner   => $owner,
     group   => $group,
     require => File[$conf_dir],
+    recurse => true,
+    purge   => true,
   }
 
   # stores properties in file structure


### PR DESCRIPTION
Closes #3. Prevents users from cleaning up when attributes or config options change.
