### PR TITLE
Don't export MESOS_work_dir since in conflicts with args passed via cmd line

### DIFF
--- a/templates/master.erb
+++ b/templates/master.erb
@@ -21,4 +21,4 @@ WHITELIST='<%= @whitelist %>'
 # EX :
 # export MESOS_log_dir=/var/log/mesos
 
-export MESOS_work_dir="<%= @work_dir %>"
+#export MESOS_work_dir="<%= @work_dir %>"


### PR DESCRIPTION
Mesos 0.19 won't start up if MESOS_work_dir gets exported.
