### PR TITLE
Adding `env_var` configuration to `mesos::master` and `mesos::config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Parameters:
         - ZooKeeper URL will be stored in `/etc/mesos/zk`
  - `conf_dir` - directory with simple configuration files containing master/slave parameters (name of the file is a key, contents its value)
         - this directory will be completely managed by Puppet
+ - `env_var` - shared master/slave execution environment variables (see example under slave)
 
 ### Master
 
@@ -52,6 +53,7 @@ class{'mesos::slave':
 ```
  - `conf_dir` default value is `/etc/mesos-master` (this directory will be purged by Puppet!)
  	- for list of supported options see `mesos-master --help`
+ - `env_var` - master's execution environment variables (see example under slave)
 
 ### Slave
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,7 @@ class mesos::config(
   $owner     = 'root',
   $group     = 'root',
   $zookeeper = '',
+  $env_var   = {},
 ){
 
   file { $log_dir:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class mesos(
   $group          = hiera('mesos::group', 'root')
   $listen_address = hiera('mesos::listen_address', $::ipaddress)
   $repo           = hiera('mesos::repo', undef)
+  $env_var        = hiera('mesos::env_var', {})
 
   class {'mesos::install':
     ensure      => $ensure,
@@ -45,6 +46,7 @@ class mesos(
     owner     => $owner,
     group     => $group,
     zookeeper => $zookeeper,
+    env_var   => $env_var,
     require   => Class['mesos::install']
   }
 

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -22,10 +22,12 @@ class mesos::master(
   $owner          = $mesos::owner,
   $group          = $mesos::group,
   $listen_address = $mesos::listen_address,
+  $env_var        = {},
   $options        = {},
   $force_provider = undef, #temporary workaround for starting services
 ) inherits mesos {
 
+  validate_hash($env_var)
   validate_hash($options)
 
   file { $conf_dir:

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -64,4 +64,21 @@ describe 'mesos::config' do
       ).with_content(/^zk:\/\/192.168.1.100:2181\/mesos/)
     }
   end
+
+  context 'setting environment variables' do
+    let(:params){{
+      :env_var => {
+        'JAVA_HOME' => '/usr/bin/java',
+        'MESOS_HOME' => '/var/lib/mesos',
+      },
+    }}
+
+    it { should contain_file(
+      '/etc/default/mesos'
+    ).with_content(/export JAVA_HOME="\/usr\/bin\/java"/) }
+
+    it { should contain_file(
+      '/etc/default/mesos'
+    ).with_content(/export MESOS_HOME="\/var\/lib\/mesos"/) }
+  end
 end

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -66,6 +66,23 @@ describe 'mesos::master' do
     it { should contain_file(file).with_content(/CLUSTER="cluster"/) }
   end
 
+  context 'setting environment variables' do
+    let(:params){{
+      :env_var => {
+        'JAVA_HOME' => '/usr/bin/java',
+        'MESOS_HOME' => '/var/lib/mesos',
+      },
+    }}
+
+    it { should contain_file(
+      file
+    ).with_content(/export JAVA_HOME="\/usr\/bin\/java"/) }
+
+    it { should contain_file(
+      file
+    ).with_content(/export MESOS_HOME="\/var\/lib\/mesos"/) }
+  end
+
   context 'disabling service' do
     let(:params){{
       :enable => false,

--- a/templates/default.erb
+++ b/templates/default.erb
@@ -7,3 +7,8 @@ USE_SYSLOG="<%= @use_syslog %>"
 # separate 'master.log' and 'slave.log' files
 LOG_DIR="<%= @log_dir %>"
 ULIMIT="-n <%= @ulimit %>"
+
+# environment variables that apply to master and slave
+<% @env_var.sort.each do |key,val| -%>
+export <%= key %>="<%= val %>"
+<% end if @env_var -%>

--- a/templates/master.erb
+++ b/templates/master.erb
@@ -20,3 +20,8 @@ WHITELIST='<%= @whitelist %>'
 # option list is available with /usr/sbin/mesos-master --help
 # EX :
 # export MESOS_log_dir=/var/log/mesos
+
+# master environment variables
+<% @env_var.sort.each do |key,val| -%>
+export <%= key %>="<%= val %>"
+<% end if @env_var -%>


### PR DESCRIPTION
This should behave the same as the existing support for setting environment variables in `mesos::slave`.

I didn't add a `validate_hash()` to `mesos::init`, because the other variables there aren't validated, but I'd be totally in to adding them in a separate commit more generally if you think that's cool.
