### PR TITLE
validate env_var

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,8 @@ class mesos(
   $repo           = hiera('mesos::repo', undef)
   $env_var        = hiera('mesos::env_var', {})
 
+  validate_hash($env_var)
+
   class {'mesos::install':
     ensure      => $ensure,
     repo_source => $repo,


### PR DESCRIPTION
I had thought there were more things in `manifests/init.pp` that were hashes and should be validated, but `$env_var` was the only one.
