### PR TITLE
Install the package before managing the $conf_dir.

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -37,6 +37,7 @@ class mesos::master(
     recurse => true,
     purge   => true,
     force   => true,
+    require => Class['::mesos::install'],
   }
 
   file { $work_dir:


### PR DESCRIPTION
Solves an issue on CentOS 6 whereby the Package is installed after the $conf_dir manifest is run.  The outcome of this is that that rpm creates a 'work_dir.rpmnew' file in $conf_dir which then breaks the service when it tries to start.

Running Puppet a second time fixes things but I want to be able to run Puppet once and let it manage its own dependencies.  In any case, it seems to make sense to install the package first.

Here's the outcome of the Puppet runs without this fix.

1st run.

```
Notice: /Stage[main]/Mesos::Master/File[/etc/mesos-master]/ensure: created
Notice: /Stage[main]/Mesos::Master/Mesos::Property[master_work_dir]/File[/etc/mesos-master/work_dir]/ensure: created
Notice: /Stage[main]/Mesos::Install/Package[mesos]/ensure: created
Notice: /Stage[main]/Mesos::Master/File[/etc/default/mesos-master]/content: content changed '{md5}7f5785adddc80756ce1012691af32e8f' to '{md5}9c68fbcfc7f77a9862adbc60df018943'
Notice: /Stage[main]/Mesos::Config/File[/etc/mesos/zk]/ensure: removed
Notice: /Stage[main]/Mesos::Config/File[/etc/default/mesos]/content: content changed '{md5}bc00e16c999da1689525c5a34a1b9efc' to '{md5}895b1069d1d25a81f572756bbfc753d1'
Notice: /Stage[main]/Mesos::Master/Mesos::Service[master]/Service[mesos-master]/ensure: ensure changed 'stopped' to 'running'
Notice: Finished catalog run in 34.40 seconds
```

Note the service is not running, /var/log/messages shows:

```
mesos-master[10915]: Failed to load unknown flag 'work_dir.rpmnew'
```

2nd run.

```
Notice: /Stage[main]/Mesos::Master/File[/etc/mesos-master/quorum]/ensure: removed
Notice: /Stage[main]/Mesos::Master/File[/etc/mesos-master/work_dir.rpmnew]/ensure: removed
Notice: /Stage[main]/Mesos::Master/Mesos::Service[master]/Service[mesos-master]/ensure: ensure changed 'stopped' to 'running'
Notice: Finished catalog run in 6.71 seconds
```
