### PR TITLE
Allow repo to be managed on redhat

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ class mesos(
   $group          = 'root',
   # could be a fact like $::ipaddress or explicit ip address
   $listen_address = undef,
-  $repo           = undef,
+  $manage_repo    = true,
   $env_var        = {},
   $ulimit         = 8192,
 ) {
@@ -47,7 +47,7 @@ class mesos(
 
   class {'mesos::install':
     ensure      => $mesos_ensure,
-    repo_source => $repo,
+    manage_repo => $manage_repo,
   }
 
   class {'mesos::config':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,7 @@
 #
 class mesos::install(
   $ensure      = $mesos::ensure,
-  $repo_source = undef,
+  $manage_repo = $mesos::manage_repo,
 ) {
   # 'ensure_packages' requires puppetlabs/stdlib
   #
@@ -22,15 +22,18 @@ class mesos::install(
   # TODO: make this optional
   ensure_packages(['python'])
 
-  class {'mesos::repo':
-    source => $repo_source,
-  }
-
   # a debian (or other binary package) must be available,
   # see https://github.com/deric/mesos-deb-packaging
   # for Debian packaging
-  package { 'mesos':
-    ensure  => $ensure,
-    require => Class['mesos::repo']
+  if ($manage_repo == true) {
+    class {'mesos::repo': }->
+    package { 'mesos':
+      ensure  => $ensure,
+    }
+  }
+  else {
+    package { 'mesos':
+      ensure  => $ensure
+    }
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,42 +1,35 @@
 # == Class mesos::repo
 #
-# This class manages apt repository for Mesos packages
+# This class manages apt/yum repositories for Mesos packages
 #
+class mesos::repo() {
 
-class mesos::repo(
-  $source = undef
-) {
-
-  if $source {
-    case $::osfamily {
-      'Debian': {
-        if !defined(Class['apt']) {
-          class { 'apt': }
-        }
-
-        $distro = downcase($::operatingsystem)
-
-        case $source {
-          undef: {} #nothing to do
-          'mesosphere': {
-            apt::source { 'mesosphere':
-              location    => "http://repos.mesosphere.io/${distro}",
-              release     => $::lsbdistcodename,
-              repos       => 'main',
-              key         => 'E56151BF',
-              key_server  => 'keyserver.ubuntu.com',
-              include_src => false,
-            }
-          }
-          default: {
-            notify { "APT repository '${source}' is not supported for ${::osfamily}": }
-          }
-        }
+  case $::osfamily {
+    'Debian': {
+      if !defined(Class['apt']) {
+        class { 'apt': }
       }
 
-      default: {
-        fail("\"${module_name}\" provides no repository information for OSfamily \"${::osfamily}\"")
+      $distro = downcase($::operatingsystem)
+
+      apt::source { 'mesosphere':
+        location    => "http://repos.mesosphere.io/${distro}",
+        release     => $::lsbdistcodename,
+        repos       => 'main',
+        key         => 'E56151BF',
+        key_server  => 'keyserver.ubuntu.com',
+        include_src => false,
       }
+    }
+    'RedHat': {
+      package { 'mesosphere-el-repo':
+        ensure   => installed,
+        provider => 'rpm',
+        source   => "http://repos.mesosphere.io/el/${::operatingsystemmajrelease}/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm"
+      }
+    }
+    default: {
+      fail("\"${module_name}\" provides no repository information for OSfamily \"${::osfamily}\"")
     }
   }
 }


### PR DESCRIPTION
Adds support for mesosphere repo management on redhat/centos. Wraps the repo management so you can turn it on/off (if you are using a custom/private yum repo)