### PR TITLE
RHEL repo addition

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -39,13 +39,13 @@ class mesos::repo(
         'mesosphere': {
           case $::operatingsystemmajrelease {
             '6': {
-              package { 'mesosphere-el-repo'
+              package { 'mesosphere-el-repo':
                 ensure => present,
                 source => 'http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm'
               }
             }
             '7': {
-              package { 'mesosphere-el-repo'
+              package { 'mesosphere-el-repo':
                 ensure => present,
                 source => 'http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm'
               }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -38,22 +38,20 @@ class mesos::repo(
           undef: {} #nothing to do
           'mesosphere': {
             $osrel = $::operatingsystemmajrelease
-
             case $osrel {
               '6': {
                 $mrel = "2"
+              }
+              '7': {
+                $mrel = "1"
+              }
+
+            case $osrel {
+              '6', '7': {
                 package { 'mesosphere-el-repo':
                   ensure => present,
                   provider => 'rpm',
                   source => "http://repos.mesosphere.io/el/${osrel}/noarch/RPMS/mesosphere-el-repo-${osrel}-${mrel}.noarch.rpm"
-                }
-              }
-              '7': {
-                $mrel = "1"
-                package { 'mesosphere-el-repo':
-                  ensure => present,
-                  provider => 'rpm',
-                  source => 'http://repos.mesosphere.io/el/${osrel}/noarch/RPMS/mesosphere-el-repo-${osrel}-${mrel}.noarch.rpm'
                 }
               }
               default: {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -33,7 +33,29 @@ class mesos::repo(
           }
         }
       }
-
+      'redhat': {
+        case $source {
+        undef: {} #nothing to do
+        'mesosphere': {
+          case $::operatingsystemmajrelease {
+            '6': {
+              package { 'mesosphere-el-repo'
+                ensure => present,
+                source => 'http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm'
+              }
+            }
+            '7': {
+              package { 'mesosphere-el-repo'
+                ensure => present,
+                source => 'http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm'
+              }
+            }
+            default: {
+              notify { "Yum repository '${source}' is not supported for major version ${::operatingsystemmajrelease}": }
+            }
+          }
+        }
+      }
       default: {
         fail("\"${module_name}\" provides no repository information for OSfamily \"${::osfamily}\"")
       }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -37,19 +37,23 @@ class mesos::repo(
         case $source {
           undef: {} #nothing to do
           'mesosphere': {
-            case $::operatingsystemmajrelease {
+            $osrel = $::operatingsystemmajrelease
+
+            case $osrel {
               '6': {
+                $mrel = "2"
                 package { 'mesosphere-el-repo':
                   ensure => present,
                   provider => 'rpm',
-                  source => 'http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm'
+                  source => "http://repos.mesosphere.io/el/${osrel}/noarch/RPMS/mesosphere-el-repo-${osrel}-${mrel}.noarch.rpm"
                 }
               }
               '7': {
+                $mrel = "1"
                 package { 'mesosphere-el-repo':
                   ensure => present,
                   provider => 'rpm',
-                  source => 'http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm'
+                  source => 'http://repos.mesosphere.io/el/${osrel}/noarch/RPMS/mesosphere-el-repo-${osrel}-${mrel}.noarch.rpm'
                 }
               }
               default: {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -45,7 +45,7 @@ class mesos::repo(
               '7': {
                 $mrel = "1"
               }
-
+            }
             case $osrel {
               '6', '7': {
                 package { 'mesosphere-el-repo':

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -41,12 +41,14 @@ class mesos::repo(
               '6': {
                 package { 'mesosphere-el-repo':
                   ensure => present,
+                  provider => 'rpm',
                   source => 'http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm'
                 }
               }
               '7': {
                 package { 'mesosphere-el-repo':
                   ensure => present,
+                  provider => 'rpm',
                   source => 'http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm'
                 }
               }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -35,23 +35,24 @@ class mesos::repo(
       }
       'redhat': {
         case $source {
-        undef: {} #nothing to do
-        'mesosphere': {
-          case $::operatingsystemmajrelease {
-            '6': {
-              package { 'mesosphere-el-repo':
-                ensure => present,
-                source => 'http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm'
+          undef: {} #nothing to do
+          'mesosphere': {
+            case $::operatingsystemmajrelease {
+              '6': {
+                package { 'mesosphere-el-repo':
+                  ensure => present,
+                  source => 'http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm'
+                }
               }
-            }
-            '7': {
-              package { 'mesosphere-el-repo':
-                ensure => present,
-                source => 'http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm'
+              '7': {
+                package { 'mesosphere-el-repo':
+                  ensure => present,
+                  source => 'http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm'
+                }
               }
-            }
-            default: {
-              notify { "Yum repository '${source}' is not supported for major version ${::operatingsystemmajrelease}": }
+              default: {
+                notify { "Yum repository '${source}' is not supported for major version ${::operatingsystemmajrelease}": }
+              }
             }
           }
         }

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -73,7 +73,6 @@ class mesos::slave (
     recurse => true,
     purge   => true,
     force   => true,
-    require => Class['::mesos::install'],
   }
 
   file { "${conf_dir}/resources":

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -73,6 +73,7 @@ class mesos::slave (
     recurse => true,
     purge   => true,
     force   => true,
+    require => Class['::mesos::install'],
   }
 
   file { "${conf_dir}/resources":


### PR DESCRIPTION
I needed to do this on RHEL6 and RHEL7 systems, so I added in the RHEL repos as valid options.  Unfortunately, the repo RPM package releases are hard-coded since the RPM to install the repo is not named ideally and does not have an alias like "latest" on the mesosphere repo, but it works well in my tests.