### PR TITLE
Allow omitting service resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,15 @@ class{'mesos::master':
 }
 ```
 
+If you want to create the service resource yourself, set `force_provider` to `none`.
+
 Some reasonable values are:
 
   * `init`
   * `upstart` - e.g. Ubuntu
   * `systemd`
   * `runit`
+  * `none`
 
 ### Packages
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,6 +4,7 @@
 #
 # Parameters:
 #  [*enable*] - enable service autostart
+#  [*force_provider*] - choose a service provider; default = undef = system default; 'none' does not create a service resource at all.
 #
 # Should not be called directly
 #
@@ -12,14 +13,16 @@ define mesos::service(
   $force_provider = undef,
 ) {
 
-  service { "mesos-${name}":
-    ensure     => 'running',
-    hasstatus  => true,
-    hasrestart => true,
-    enable     => $enable,
-    provider   => $force_provider,
-    subscribe  => [ File['/etc/default/mesos'],
-      File["/etc/default/mesos-${name}"]
-    ],
+  if ($force_provider != 'none') {
+    service { "mesos-${name}":
+      ensure     => 'running',
+      hasstatus  => true,
+      hasrestart => true,
+      enable     => $enable,
+      provider   => $force_provider,
+      subscribe  => [ File['/etc/default/mesos'],
+        File["/etc/default/mesos-${name}"]
+      ],
+    }
   }
 }


### PR DESCRIPTION
I need the possibility to omitt the servce resource definition completely.
Our wrapper handling services is creating a custom service resource using monit etc.
For some special reasons, I'm not able to write a monit service provider I could reach into this class.