### PR TITLE
Fix Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,17 @@ env:
   - PUPPET_VERSION=3.3.2
   - PUPPET_VERSION=3.4.3
   - PUPPET_VERSION=3.5.1
+  - PUPPET_VERSION=3.6.2
+  - PUPPET_VERSION=3.7.5
   - RSPEC_VERSION=2.14
 matrix:
   exclude:
     - rvm: 1.9.2
       env: PUPPET_VERSION=2.6.18
+    - rvm: 1.9.2
+      env: PUPPET_VERSION=3.6.2
+    - rvm: 1.9.2
+      env: PUPPET_VERSION=3.7.5
     - rvm: 1.9.3
       env: PUPPET_VERSION=2.6.18
     - rvm: 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ rvm:
   - 2.0.0
   - 2.1.2
 env:
-  - PUPPET_VERSION=2.6.18
   - PUPPET_VERSION=2.7.23
-  - PUPPET_VERSION=3.0.2
   - PUPPET_VERSION=3.1.1
   - PUPPET_VERSION=3.2.4
   - PUPPET_VERSION=3.3.2
@@ -22,27 +20,15 @@ env:
 matrix:
   exclude:
     - rvm: 1.9.2
-      env: PUPPET_VERSION=2.6.18
-    - rvm: 1.9.2
       env: PUPPET_VERSION=3.6.2
     - rvm: 1.9.2
       env: PUPPET_VERSION=3.7.5
-    - rvm: 1.9.3
-      env: PUPPET_VERSION=2.6.18
-    - rvm: 2.0.0
-      env: PUPPET_VERSION=2.6.18
     - rvm: 2.0.0
       env: PUPPET_VERSION=2.7.23
-    - rvm: 2.0.0
-      env: PUPPET_VERSION=3.0.2
     - rvm: 2.0.0
       env: PUPPET_VERSION=3.1.1
     - rvm: 2.1.2
-      env: PUPPET_VERSION=2.6.18
-    - rvm: 2.1.2
       env: PUPPET_VERSION=2.7.23
-    - rvm: 2.1.2
-      env: PUPPET_VERSION=3.0.2
     - rvm: 2.1.2
       env: PUPPET_VERSION=3.1.1
     - rvm: 2.1.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
 group :rake do
-  gem 'puppet',  '>= 2.7.0'
+  puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['>= 2.7.0','< 4.0']
+  gem 'puppet', puppetversion
   gem 'puppet-lint'
   gem 'puppetlabs_spec_helper', '>=0.2.0'
   gem 'rake',         '>=0.9.2.2'


### PR DESCRIPTION
Fix Gemfile to use PUPPET_VERSION environment variable. Restrict Puppet to < 4.0. Add testing for Puppet 3.6.2 and 3.7.5.
Tests on Travis were not honoring the requested Puppet version, as the Gemfile was not using the PUPPET_VERSION environment variable. Puppet 4.0 was added to Gem, which has breaking changes.