### PR TITLE
Added manage_zk_file parameter, tests, and documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ Parameters:
  - `zookeeper` - ZooKeeper URL which is used for slaves connecting to the master and also for leader election, e.g.:
 	- single ZooKeeper: `zk://127.0.0.1:2181/mesos` (which isn't fault tolerant)
         - multiple ZooKeepers: `zk://192.168.1.1:2181,192.168.1.2:2181,192.168.1.3:2181/mesos` (usually 3 or 5 ZooKeepers should be enough)
-        - ZooKeeper URL will be stored in `/etc/mesos/zk`
+        - ZooKeeper URL will be stored in `/etc/mesos/zk`, `/etc/default/mesos-master` and/or `/etc/default/mesos-slave`
  - `conf_dir` - directory with simple configuration files containing master/slave parameters (name of the file is a key, contents its value)
         - this directory will be completely managed by Puppet
  - `env_var` - shared master/slave execution environment variables (see example under slave)
  - `version` - install specific version of Mesos
  - `manage_python` - Control whether mesos module should install python
+ - `manage_zk_file` - Control whether module manages /etc/mesos/zk (default: true)
 
 ### Master
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,22 +3,24 @@
 # This module manages the mesos configuration directories
 #
 # Parameters:
-#  [*log_dir*]  - directory for logging (default: /var/log/mesos)
-#  [*conf_dir*] - directory for configuration files (default: /etc/mesos)
-#  [*owner*]    - owner of configuration files
-#  [*group*]    - group of configuration files
+#  [*log_dir*]        - directory for logging (default: /var/log/mesos)
+#  [*conf_dir*]       - directory for configuration files (default: /etc/mesos)
+#  [*manage_zk_file*] - flag whether module manages /etc/mesos/zk (default: true)
+#  [*owner*]          - owner of configuration files
+#  [*group*]          - group of configuration files
 #
 # This class should not be included directly,
 # always use 'mesos::slave' or 'mesos:master'
 #
 class mesos::config(
-  $log_dir   = '/var/log/mesos',
-  $ulimit    = 8192,
-  $conf_dir  = '/etc/mesos',
-  $owner     = 'root',
-  $group     = 'root',
-  $zookeeper = '',
-  $env_var   = {},
+  $log_dir        = '/var/log/mesos',
+  $ulimit         = 8192,
+  $conf_dir       = '/etc/mesos',
+  $manage_zk_file = true,
+  $owner          = 'root',
+  $group          = 'root',
+  $zookeeper      = '',
+  $env_var        = {},
 ){
 
   file { $log_dir:
@@ -42,15 +44,17 @@ class mesos::config(
     require => Package['mesos'],
   }
 
-  # file containing only zookeeper URL
-  file { '/etc/mesos/zk':
-    ensure  => empty($zookeeper) ? {
-      true  => absent,
-      false => present,
-    },
-    content => $zookeeper,
-    owner   => $owner,
-    group   => $group,
+  if $manage_zk_file {
+    # file containing only zookeeper URL
+    file { '/etc/mesos/zk':
+      ensure  => empty($zookeeper) ? {
+        true  => absent,
+        false => present,
+      },
+      content => $zookeeper,
+      owner   => $owner,
+      group   => $group,
+    }
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@ class mesos(
   # TODO: currently not used
   $log_dir        = '/var/log/mesos',
   $conf_dir       = '/etc/mesos',
+  $manage_zk_file = true,
   # e.g. zk://localhost:2181/mesos
   $zookeeper      = '',
   # if "zk" is empty, master value is used
@@ -55,14 +56,15 @@ class mesos(
   }
 
   class {'mesos::config':
-    log_dir   => $log_dir,
-    conf_dir  => $conf_dir,
-    owner     => $owner,
-    group     => $group,
-    zookeeper => $zookeeper,
-    env_var   => $env_var,
-    ulimit    => $ulimit,
-    require   => Class['mesos::install']
+    log_dir        => $log_dir,
+    conf_dir       => $conf_dir,
+    manage_zk_file => $manage_zk_file,
+    owner          => $owner,
+    group          => $group,
+    zookeeper      => $zookeeper,
+    env_var        => $env_var,
+    ulimit         => $ulimit,
+    require        => Class['mesos::install']
   }
 
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -65,6 +65,17 @@ describe 'mesos::config' do
     }
   end
 
+  context 'with manage_zk_file false' do
+    let(:params){{
+      :manage_zk_file => false,
+      :zookeeper      => 'zk://192.168.1.100:2181/mesos',
+    }}
+    it { should_not contain_file(
+      '/etc/mesos/zk'
+      )
+    }
+  end
+
   context 'setting environment variables' do
     let(:params){{
       :env_var => {


### PR DESCRIPTION
/etc/mesos/zk is not necessary for mesos-master or mesos-slave, and this module already adds ZK="<zk URL(s)>" to /etc/default/mesos-master and MASTER="<zk URL(s)>" to /etc/default/mesos-slave - which is what Mesos ends up using. /etc/mesos/zk, on the other hand, is hardcoded in the Marathon framework to be used. I have created a module to configure Marathon, and I am having it manage /etc/mesos/zk.

This PR adds a parameter to the deric-mesos module to enable/disable management of /etc/mesos/zk by this module. This parameter, manage_zk_file, defaults to true to maintain backwards compatibility for users of the module.

This aim of this PR, and associated discussion, can be found at PR https://github.com/deric/puppet-mesos/pull/31