### PR TITLE
Fix use_syslog option for default.erb template

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,6 +15,7 @@
 class mesos::config(
   $log_dir        = '/var/log/mesos',
   $ulimit         = 8192,
+  $use_syslog     = false,
   $conf_dir       = '/etc/mesos',
   $manage_zk_file = true,
   $owner          = 'root',

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -44,7 +44,6 @@ class mesos::slave (
   $isolation      = '',
   $conf_dir       = '/etc/mesos-slave',
   $conf_file      = '/etc/default/mesos-slave',
-  $use_syslog     = false,
   $master         = $mesos::master,
   $master_port    = $mesos::master_port,
   $zookeeper      = $mesos::zookeeper,


### PR DESCRIPTION
`use_syslog` option was implemented in the slave.pp, but it should be configured in config.pp?
