### PR TITLE
Turn actions in the superclass into a define.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,12 +31,6 @@ class mesos::config(
     group  => $group,
   }
 
-  file { $conf_dir:
-    ensure => directory,
-    owner  => $owner,
-    group  => $group,
-  }
-
   file { '/etc/default/mesos':
     ensure  => 'present',
     content => template('mesos/default.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,24 +49,50 @@ class mesos(
     default  => $version,
   }
 
-  class {'mesos::install':
-    ensure         => $mesos_ensure,
-    repo_source    => $repo,
-    manage_python  => $manage_python,
-    python_package => $python_package,
-  }
+  define common(
+    $repo,
+    $manage_python,
+    $python_package,
+    $log_dir,
+    $conf_dir,
+    $manage_zk_file,
+    $owner,
+    $group,
+    $zookeeper,
+    $env_var,
+    $ulimit,
+    $use_syslog
+    ) {
 
-  class {'mesos::config':
-    log_dir        => $log_dir,
-    conf_dir       => $conf_dir,
-    manage_zk_file => $manage_zk_file,
-    owner          => $owner,
-    group          => $group,
-    zookeeper      => $zookeeper,
-    env_var        => $env_var,
-    ulimit         => $ulimit,
-    use_syslog     => $use_syslog,
-    require        => Class['mesos::install']
+    file { $conf_dir:
+      ensure  => directory,
+      owner   => $owner,
+      group   => $group,
+      recurse => true,
+      purge   => true,
+      force   => true,
+      require => Class['::mesos::install'],
+    }
+
+    class {'mesos::install':
+      ensure         => $mesos_ensure,
+      repo_source    => $repo,
+      manage_python  => $manage_python,
+      python_package => $python_package,
+    }
+    
+    class {'mesos::config':
+      log_dir        => $log_dir,
+      conf_dir       => $conf_dir,
+      manage_zk_file => $manage_zk_file,
+      owner          => $owner,
+      group          => $group,
+      zookeeper      => $zookeeper,
+      env_var        => $env_var,
+      ulimit         => $ulimit,
+      use_syslog     => $use_syslog,
+      require        => Class['mesos::install']
+    }
   }
 
 }

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -30,14 +30,19 @@ class mesos::master(
   validate_hash($env_var)
   validate_hash($options)
 
-  file { $conf_dir:
-    ensure  => directory,
-    owner   => $owner,
-    group   => $group,
-    recurse => true,
-    purge   => true,
-    force   => true,
-    require => Class['::mesos::install'],
+  mesos::common { "master":
+    repo => $repo,
+    manage_python => $manage_python,
+    python_package => $python_package,
+    log_dir => $log_dir,
+    conf_dir => $conf_dir,
+    manage_zk_file => $manage_zk_file,
+    owner => $owner,
+    group => $group,
+    zookeeper => $zookeeper,
+    env_var => $env_var,
+    ulimit => $ulimit,
+    use_syslog => $use_syslog
   }
 
   file { $work_dir:

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -57,7 +57,6 @@ class mesos::slave (
   $attributes     = {},
   $force_provider = undef, #temporary workaround for starting services
 ) inherits mesos {
-
   validate_hash($env_var)
   validate_hash($cgroups)
   validate_hash($options)
@@ -65,13 +64,19 @@ class mesos::slave (
   validate_hash($attributes)
   validate_string($isolation)
 
-  file { $conf_dir:
-    ensure  => directory,
-    owner   => $owner,
-    group   => $group,
-    recurse => true,
-    purge   => true,
-    force   => true,
+  mesos::common { "slave":
+    repo => $repo,
+    manage_python => $manage_python,
+    python_package => $python_package,
+    log_dir => $log_dir,
+    conf_dir => $conf_dir,
+    manage_zk_file => $manage_zk_file,
+    owner => $owner,
+    group => $group,
+    zookeeper => $zookeeper,
+    env_var => $env_var,
+    ulimit => $ulimit,
+    use_syslog => $use_syslog
   }
 
   file { "${conf_dir}/resources":


### PR DESCRIPTION
As per the recommendation of
https://stackoverflow.com/questions/15627779/#answer-15628828 : this technique
allows default values to propagate to the common (superclass) actions, without
being forced to use a global value setting mechanism such as Hiera.
- The define takes all its information as parameters, except for
  $mesos_ensure that it simply closes over in the parent class
  ($mesos_ensure is a private variable and there is little point in
  overriding it; users would want to set $version instead)
- In call sites (both subclasses), pass all parameters along from the
  current scope, that is, the superclass if no overrides take place -
  thus keeping the correct data flow when Hiera is in use
- Hoist file { $conf_dir: } into mesos::common (was previously a duplicate
  resource between superclass and derived class, yet working for some reason)
