### PR TITLE
Source package repository shouldn't be added for Debian/Ubuntu

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -20,10 +20,11 @@ class mesos::repo(
           undef: {} #nothing to do
           'mesosphere': {
             apt::source { 'mesosphere':
-              location => "http://repos.mesosphere.io/${distro}",
-              release  => $::lsbdistcodename,
-              repos    => 'main',
-              key      => '81026D0004C44CF7EF55ADF8DF7D54CBE56151BF',
+              location    => "http://repos.mesosphere.io/${distro}",
+              release     => $::lsbdistcodename,
+              repos       => 'main',
+              key         => '81026D0004C44CF7EF55ADF8DF7D54CBE56151BF',
+              include_src => false
             }
           }
           default: {

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -16,10 +16,11 @@ describe 'mesos::repo', :type => :class do
     }}
 
     it { should contain_apt__source('mesosphere').with(
-     'location' => "http://repos.mesosphere.io/#{operatingsystem.downcase}",
-     'repos'    => 'main',
-     'release'  => "#{lsbdistcodename}",
-     'key'      => '81026D0004C44CF7EF55ADF8DF7D54CBE56151BF',
+     'location'    => "http://repos.mesosphere.io/#{operatingsystem.downcase}",
+     'repos'       => 'main',
+     'release'     => "#{lsbdistcodename}",
+     'key'         => '81026D0004C44CF7EF55ADF8DF7D54CBE56151BF',
+     'include_src' => false
     )}
 
     context "undef source" do


### PR DESCRIPTION
Found the following error when enabling mesosphere.io repository for Debian/Ubuntu:
```
Notice: /Stage[main]/Apt::Update/Exec[apt_update]/returns: W: Failed to fetch http://repos.mesosphere.io/ubuntu/dists/trusty/InRelease
Unable to find expected entry 'main/source/Sources' in Release file (Wrong sources.list entry or malformed file)
```
In fact, and according to official documentation https://open.mesosphere.com/getting-started/datacenter/install/, only the binary package repository should be added.