### PR TITLE
Update incompatible changes of puppetlabs-apt 2.0.0

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -23,7 +23,9 @@ class mesos::repo(
               location => "http://repos.mesosphere.io/${distro}",
               release  => $::lsbdistcodename,
               repos    => 'main',
-              key      => '81026D0004C44CF7EF55ADF8DF7D54CBE56151BF',
+              key      => {
+                'id'     => '81026D0004C44CF7EF55ADF8DF7D54CBE56151BF',
+                'server' => 'subkeys.pgp.net',
             }
           }
           default: {


### PR DESCRIPTION
Puppetlabs-apt 2.0.0 broke apt::source https://github.com/puppetlabs/puppetlabs-apt/blob/master/CHANGELOG.md#2015-04-07---supported-release-200 this PR updates the apt::source so it works.