### PR TITLE
Moving to a more reliable public GPG key server for 'Debian' osfamily

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -25,7 +25,7 @@ class mesos::repo(
               repos    => 'main',
               key      => {
                 'id'     => '81026D0004C44CF7EF55ADF8DF7D54CBE56151BF',
-                'server' => 'subkeys.pgp.net',
+                'server' => 'keyserver.ubuntu.com',
               },
               include  => { 'src' => false }
             }

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -19,7 +19,7 @@ describe 'mesos::repo', :type => :class do
      'location' => "http://repos.mesosphere.io/#{operatingsystem.downcase}",
      'repos'    => 'main',
      'release'  => "#{lsbdistcodename}",
-     'key'      => {'id' => '81026D0004C44CF7EF55ADF8DF7D54CBE56151BF', 'server' => 'subkeys.pgp.net'},
+     'key'      => {'id' => '81026D0004C44CF7EF55ADF8DF7D54CBE56151BF', 'server' => 'keyserver.ubuntu.com'},
      'include'  => {'src' => false}
     )}
 


### PR DESCRIPTION
I've been experiencing a lot of timeouts when using `subkeys.pgp.net` as the public GPG key server for the 'Debian' osfamily. I would propose to move to `keyserver.ubuntu.com`, I find it a much more reliable key server.