### PR TITLE
Force an apt-get update before trying to install packages

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -30,7 +30,6 @@ class mesos::repo(
               include  => { 'src' => false }
             }
           include apt::update
-          Exec['apt_update'] -> Package['mesos']
           }
           default: {
             notify { "APT repository '${source}' is not supported for ${::osfamily}": }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -30,7 +30,7 @@ class mesos::repo(
               include  => { 'src' => false }
             }
           include apt::update
-          Exec['apt_update'] -> Package <| |>
+          Exec['apt_update'] -> Package['mesos']
           }
           default: {
             notify { "APT repository '${source}' is not supported for ${::osfamily}": }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -29,6 +29,8 @@ class mesos::repo(
               },
               include  => { 'src' => false }
             }
+          include apt::update
+          Exec['apt_update'] -> Package <| |>
           }
           default: {
             notify { "APT repository '${source}' is not supported for ${::osfamily}": }


### PR DESCRIPTION
If a new repo is installed, it should do an apt-get update before trying to install or will fail until a second puppet run it's issued:

```
Notice: Compiled catalog for mesosmaster1 in environment production in 0.50 seconds
Notice: /Stage[main]/Mesos::Repo/Apt::Source[mesosphere]/Apt::Setting[list-mesosphere]/File[/etc/apt/sources.list.d/mesosphere.list]/ensure: created
Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install mesos' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
Package mesos is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
```

I don't know if in RHEL/CentOS have the same problem.