### PR TITLE
fix compiler error when property is numeric (in future parser)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pkg/*
 .bundle
 Gemfile.lock
 Puppetfile.lock
+vendor/

--- a/manifests/property.pp
+++ b/manifests/property.pp
@@ -15,6 +15,10 @@ define mesos::property (
     }
     $ensure = 'present'
     $content = ''
+  } elsif is_numeric($value) {
+    $filename = "${dir}/${file}"
+    $ensure = 'present'
+    $content = "${value}"
   } else {
     $filename = "${dir}/${file}"
     $ensure = empty($value) ? {

--- a/spec/defines/property_spec.rb
+++ b/spec/defines/property_spec.rb
@@ -82,7 +82,23 @@ describe 'mesos::property', :type => :define do
     end
   end
 
-  context 'with a numeric value' do
+  context 'with a integer value' do
+    let(:params) {{
+      :value   => 314,
+      :dir     => directory,
+      :service => '',
+    }}
+
+    it 'should contain a property file' do
+        should contain_file(
+          "#{directory}/#{title}"
+        ).with_content(/^314$/).with({
+      'ensure'  => 'present',
+      })
+    end
+  end
+
+  context 'with a float value' do
     let(:params) {{
       :value   => 3.14,
       :dir     => directory,


### PR DESCRIPTION
split into integer/float in specs can go away but i don't trust puppet being very coherent in future.

vendor/gems in .gitignore mainly there for convenience, it is default path bundler install suggests.