### PR TITLE
support credentials and acls

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ class{'mesos::slave':
  - `conf_dir` default value is `/etc/mesos-master` (this directory will be purged by Puppet!)
  	- for list of supported options see `mesos-master --help`
  - `env_var` - master's execution environment variables (see example under slave)
+ - `acls` - hash of mesos acls, `{"permissive" => true, "register_frameworks" => [..]}` (default: `{}`)
+ - `acls_file` - path to file to store acls (default: `/etc/mesos/acls`)
  - `credentials` - array of mesos credentials, `[{'principal' => 'some-principal', 'secret' => 'some-secret'}]` (default: `[]`)
  - `credentials_file` - path to file to store credentials (default: `/etc/mesos/master-credentials`)
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ class{'mesos::slave':
  - `conf_dir` default value is `/etc/mesos-master` (this directory will be purged by Puppet!)
  	- for list of supported options see `mesos-master --help`
  - `env_var` - master's execution environment variables (see example under slave)
+ - `credentials` - array of mesos credentials, `[{'principal' => 'some-principal', 'secret' => 'some-secret'}]` (default: `[]`)
+ - `credentials_file` - path to file to store credentials (default: `/etc/mesos/master-credentials`)
 
 #### listen address
 
@@ -114,6 +116,9 @@ By default no IP address is set, which means that Mesos will use IP to which tra
  - `work_dir` - directory for storing task's temporary files (default: `/tmp/mesos`)
  - `env_var` - slave's execution environment variables - a Hash, if you are using
  Java, you might need e.g.:
+ - `principal` - mesos principal used for auththentication
+ - `secret` - secret used for auththentication
+ - `credentials_file` - path to file to store credentials (default: `/etc/mesos/slave-credentials`)
 
 ```puppet
 class{'mesos::slave':

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -11,26 +11,42 @@
 # structure. Arguments passed via $options hash are converted to file/directories
 #
 class mesos::master(
-  $enable         = true,
-  $whitelist      = '*',
-  $cluster        = 'mesos',
-  $conf_dir       = '/etc/mesos-master',
-  $work_dir       = '/var/lib/mesos', # registrar directory, since 0.19
-  $conf_file      = '/etc/default/mesos-master',
-  $master_port    = $mesos::master_port,
-  $zookeeper      = $mesos::zookeeper,
-  $owner          = $mesos::owner,
-  $group          = $mesos::group,
-  $listen_address = $mesos::listen_address,
-  $manage_service = $mesos::manage_service,
-  $env_var        = {},
-  $options        = {},
-  $force_provider = undef, #temporary workaround for starting services
+  $enable           = true,
+  $whitelist        = '*',
+  $cluster          = 'mesos',
+  $conf_dir         = '/etc/mesos-master',
+  $work_dir         = '/var/lib/mesos', # registrar directory, since 0.19
+  $conf_file        = '/etc/default/mesos-master',
+  $credentials_file = '/etc/mesos/master-credentials',
+  $master_port      = $mesos::master_port,
+  $zookeeper        = $mesos::zookeeper,
+  $owner            = $mesos::owner,
+  $group            = $mesos::group,
+  $listen_address   = $mesos::listen_address,
+  $manage_service   = $mesos::manage_service,
+  $env_var          = {},
+  $options          = {},
+  $credentials      = [],
+  $force_provider   = undef, #temporary workaround for starting services
 ) inherits mesos {
 
   validate_hash($env_var)
   validate_hash($options)
+  validate_array($credentials)
+  validate_absolute_path($credentials_file)
   validate_bool($manage_service)
+
+  if (!empty($credentials)) {
+    $credentials_options = {'credentials' => $credentials_file}
+    $credentials_content = inline_template("<%= {:credentials => @credentials}.to_json %>")
+    $credentials_ensure = file
+  } else {
+    $credentials_options = {}
+    $credentials_content = undef
+    $credentials_ensure = absent
+  }
+
+  $merged_options = merge($options, $credentials_options)
 
   file { $conf_dir:
     ensure  => directory,
@@ -48,6 +64,14 @@ class mesos::master(
     group  => $group,
   }
 
+  file { $credentials_file:
+    ensure  => $credentials_ensure,
+    content => $credentials_content,
+    owner   => $owner,
+    group   => $group,
+    mode    => '0400',
+  }
+
   # work_dir can't be specified via options,
   # we would get a duplicate declaration error
   mesos::property {'master_work_dir':
@@ -59,7 +83,7 @@ class mesos::master(
   }
 
   create_resources(mesos::property,
-    mesos_hash_parser($options, 'master'),
+    mesos_hash_parser($merged_options, 'master'),
     {
       dir     => $conf_dir,
       service => Service['mesos-master'],

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -17,6 +17,7 @@ class mesos::master(
   $conf_dir         = '/etc/mesos-master',
   $work_dir         = '/var/lib/mesos', # registrar directory, since 0.19
   $conf_file        = '/etc/default/mesos-master',
+  $acls_file        = '/etc/mesos/acls',
   $credentials_file = '/etc/mesos/master-credentials',
   $master_port      = $mesos::master_port,
   $zookeeper        = $mesos::zookeeper,
@@ -26,19 +27,32 @@ class mesos::master(
   $manage_service   = $mesos::manage_service,
   $env_var          = {},
   $options          = {},
+  $acls             = {},
   $credentials      = [],
   $force_provider   = undef, #temporary workaround for starting services
 ) inherits mesos {
 
   validate_hash($env_var)
   validate_hash($options)
+  validate_hash($acls)
+  validate_absolute_path($acls_file)
   validate_array($credentials)
   validate_absolute_path($credentials_file)
   validate_bool($manage_service)
 
+  if (!empty($acls)) {
+    $acls_options = {'acls' => $acls_file}
+    $acls_content = inline_template("<%= require 'json'; @acls.to_json %>")
+    $acls_ensure = file
+  } else {
+    $acls_options = {}
+    $acls_content = undef
+    $acls_ensure = absent
+  }
+
   if (!empty($credentials)) {
     $credentials_options = {'credentials' => $credentials_file}
-    $credentials_content = inline_template("<%= {:credentials => @credentials}.to_json %>")
+    $credentials_content = inline_template("<%= require 'json'; {:credentials => @credentials}.to_json %>")
     $credentials_ensure = file
   } else {
     $credentials_options = {}
@@ -46,7 +60,7 @@ class mesos::master(
     $credentials_ensure = absent
   }
 
-  $merged_options = merge($options, $credentials_options)
+  $merged_options = merge($options, $acls_options, $credentials_options)
 
   file { $conf_dir:
     ensure  => directory,
@@ -62,6 +76,14 @@ class mesos::master(
     ensure => directory,
     owner  => $owner,
     group  => $group,
+  }
+
+  file { $acls_file:
+    ensure  => $acls_ensure,
+    content => $acls_content,
+    owner   => $owner,
+    group   => $group,
+    mode    => '0444',
   }
 
   file { $credentials_file:

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -175,6 +175,58 @@ describe 'mesos::master', :type => :class do
     end
   end
 
+  context 'acls' do
+    context 'default w/o acls' do
+      let(:params) { {
+          :conf_dir => conf,
+          :owner => owner,
+          :group => group,
+      } }
+
+      it 'has no acls property' do
+        should_not contain_mesos__property(
+                       'master_acls'
+                   )
+      end
+
+      it 'has not acls file' do
+        should contain_file(
+                   '/etc/mesos/acls'
+               )
+                   .with({
+                             'ensure' => 'absent',
+                         })
+      end
+    end
+
+    context 'w/ acls' do
+      let(:params) { {
+          :conf_dir => conf,
+          :owner => owner,
+          :group => group,
+          :acls => {"some-key" => ["some-value", "some-other-value"]},
+      } }
+
+      it 'has acls property' do
+        should contain_mesos__property(
+                   'master_acls'
+               ).with('value' => '/etc/mesos/acls')
+      end
+
+      it 'has acls file' do
+        should contain_file(
+                   '/etc/mesos/acls'
+               ).with({
+                          'ensure' => 'file',
+                          'content' => /{"some-key":\s*\["some-value",\s*"some-other-value"\]}/,
+                          'owner' => owner,
+                          'group' => group,
+                          'mode' => '0444',
+                      })
+      end
+    end
+  end
+
   context 'credentials' do
     context 'default w/o credentials' do
       let(:params) { {

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -175,4 +175,57 @@ describe 'mesos::master', :type => :class do
     end
   end
 
+  context 'credentials' do
+    context 'default w/o credentials' do
+      let(:params) { {
+          :conf_dir => conf,
+          :owner => owner,
+          :group => group,
+      } }
+
+      it 'has no credentials property' do
+        should_not contain_mesos__property(
+                       'master_credentials'
+                   )
+      end
+
+      it 'has not credentials file' do
+        should contain_file(
+                   '/etc/mesos/master-credentials'
+               )
+                   .with({
+                             'ensure' => 'absent',
+                         })
+      end
+    end
+
+    context 'w/ credentials' do
+      let(:params) { {
+          :conf_dir => conf,
+          :owner => owner,
+          :group => group,
+          :credentials => [{'principal' => 'some-mesos-principal', 'secret' => 'a-very-secret'}],
+      } }
+
+      it 'has credentials property' do
+        should contain_mesos__property(
+                   'master_credentials'
+               ).with({
+                          'value' => '/etc/mesos/master-credentials',
+                      })
+      end
+
+      it 'has credentials file' do
+        should contain_file(
+                   '/etc/mesos/master-credentials'
+               ).with({
+                          'ensure' => 'file',
+                          'content' => /{"credentials":\s*\[{"principal":\s*"some-mesos-principal",\s*"secret":\s*"a-very-secret"}\]}/,
+                          'owner' => owner,
+                          'group' => group,
+                          'mode' => '0400',
+                      })
+      end
+    end
+  end
 end

--- a/spec/classes/slave_spec.rb
+++ b/spec/classes/slave_spec.rb
@@ -327,4 +327,59 @@ describe 'mesos::slave', :type => :class do
       })
     end
   end
+
+  context 'credentials' do
+    context 'default w/o principal/secret' do
+      let(:params) { {
+          :conf_dir => conf,
+          :owner => owner,
+          :group => group,
+      } }
+
+      it 'has no credentials property' do
+        should_not contain_mesos__property(
+                       'slave_credentials'
+                   )
+      end
+
+      it 'has not credentials file' do
+        should contain_file(
+                   '/etc/mesos/slave-credentials'
+               )
+                   .with({
+                             'ensure' => 'absent',
+                         })
+      end
+    end
+
+    context 'w/ principal/secret' do
+      let(:params) { {
+          :conf_dir => conf,
+          :owner => owner,
+          :group => group,
+          :principal => 'some-mesos-principal',
+          :secret => 'a-very-secret',
+      } }
+
+      it 'has credentials property' do
+        should contain_mesos__property(
+                   'slave_credentials'
+               ).with({
+                          'value' => '/etc/mesos/slave-credentials',
+                      })
+      end
+
+      it 'has credentials file' do
+        should contain_file(
+                   '/etc/mesos/slave-credentials'
+               ).with({
+                          'ensure' => 'file',
+                          'content' => '{"principal": "some-mesos-principal", "secret": "a-very-secret"}',
+                          'owner' => owner,
+                          'group' => group,
+                          'mode' => '0400',
+                      })
+      end
+    end
+  end
 end


### PR DESCRIPTION
This changes allows setting credentials for mesos master and slave as well as acls for mesos master in json format.
Note, that mesos <0.26 reads secrets as base64 encoded byte array, mesos >=0.26 reads secrets as plain strings.
This is irrelevant, if authentication is used for slaves only. It's important for framework authentication though.