### PR TITLE
remove upstart service definition shipped with rpm for RHEL 6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@ class mesos(
   $ulimit         = 8192,
   $manage_python  = false,
   $python_package = 'python',
+  $force_provider = undef, #temporary workaround for starting services
 ) {
   validate_hash($env_var)
   validate_bool($manage_zk_file)
@@ -52,10 +53,11 @@ class mesos(
   }
 
   class {'mesos::install':
-    ensure         => $mesos_ensure,
-    repo_source    => $repo,
-    manage_python  => $manage_python,
-    python_package => $python_package,
+    ensure                  => $mesos_ensure,
+    repo_source             => $repo,
+    manage_python           => $manage_python,
+    python_package          => $python_package,
+    remove_package_services => $force_provider == 'none',
   }
 
   class {'mesos::config':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,10 +10,11 @@
 # required by 'mesos::master' and 'mesos::slave'
 #
 class mesos::install(
-  $ensure         = 'present',
-  $repo_source    = undef,
-  $manage_python  = false,
-  $python_package = 'python',
+  $ensure                  = 'present',
+  $repo_source             = undef,
+  $manage_python           = false,
+  $python_package          = 'python',
+  $remove_package_services = false,
 ) {
   # 'ensure_packages' requires puppetlabs/stdlib
   #
@@ -37,5 +38,14 @@ class mesos::install(
   package { 'mesos':
     ensure  => $ensure,
     require => Class['mesos::repo']
+  }
+
+  if ($remove_package_services and $::osfamily == 'redhat' and $::operatingsystemmajrelease == '6') {
+    file { [
+      '/etc/init/mesos-master.conf', '/etc/init/mesos-slave.conf'
+    ]:
+      ensure  => absent,
+      require => Package['mesos'],
+    }
   }
 }

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -23,9 +23,9 @@ class mesos::master(
   $group          = $mesos::group,
   $listen_address = $mesos::listen_address,
   $manage_service = $mesos::manage_service,
+  $force_provider = $mesos::force_provider,
   $env_var        = {},
   $options        = {},
-  $force_provider = undef, #temporary workaround for starting services
 ) inherits mesos {
 
   validate_hash($env_var)

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -77,4 +77,18 @@ describe 'mesos', :type => :class do
 
     it { should contain_file(file).with_content(/LOGS="\/var\/log\/mesos"/) }
   end
+
+  context 'remove packaged services' do
+    context 'keeps everything' do
+      it { should contain_class('mesos::install').with('remove_package_services' => false) }
+    end
+
+    context 'remvoes packaged upstart config' do
+      let(:params) {{
+          :force_provider => 'none'
+      }}
+
+      it { should contain_class('mesos::install').with('remove_package_services' => true) }
+    end
+  end
 end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -26,4 +26,38 @@ describe 'mesos::install', :type => :class do
       }}
     it { should contain_package('python') }
   end
+
+  context 'remove packaged services' do
+    context 'keeps everything' do
+      it { should_not contain_file('/etc/init/mesos-master.conf') }
+      it { should_not contain_file('/etc/init/mesos-slave.conf') }
+    end
+
+    context 'keeps everything on RHEL 7' do
+      let(:facts) { {
+          :osfamily => 'redhat',
+          :operatingsystemmajrelease => '7',
+      } }
+      let(:params) { {
+          :remove_package_services => true,
+      } }
+
+      it { should_not contain_file('/etc/init/mesos-master.conf') }
+      it { should_not contain_file('/etc/init/mesos-slave.conf') }
+    end
+
+    context 'removes packaged upstart config on RHEL 6' do
+      let(:facts) { {
+          :osfamily => 'redhat',
+          :operatingsystemmajrelease => '6',
+      } }
+
+      let(:params) { {
+          :remove_package_services => true,
+      } }
+
+      it { should contain_file('/etc/init/mesos-master.conf').with_ensure('absent') }
+      it { should contain_file('/etc/init/mesos-slave.conf').with_ensure('absent') }
+    end
+  end
 end


### PR DESCRIPTION
The mesos rpm for RHEL6 ships upstart service definitions.
This leads to enabled service on any machine the RPM is installed, even if the package is installed only to install the libmesos.so.

By setting `mesos::force_provider` to `none` these upstart files are removed on RHEL6 machines.