### PR TITLE
Add owner and group parameters to mesos::property

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -100,6 +100,8 @@ class mesos::master(
     value   => $work_dir,
     dir     => $conf_dir,
     file    => 'work_dir',
+    owner   => $owner,
+    group   => $group,
     service => Service['mesos-master'],
     require => File[$conf_dir],
   }
@@ -108,6 +110,8 @@ class mesos::master(
     mesos_hash_parser($merged_options, 'master'),
     {
       dir     => $conf_dir,
+      owner   => $owner,
+      group   => $group,
       service => Service['mesos-master'],
     }
   )

--- a/manifests/property.pp
+++ b/manifests/property.pp
@@ -6,6 +6,8 @@ define mesos::property (
   $dir,
   $service, #service to be notified about property changes
   $file = $title,
+  $owner = 'root',
+  $group = 'root',
 ) {
 
   if is_bool($value) {
@@ -31,6 +33,8 @@ define mesos::property (
   file { $filename:
     ensure  => $ensure,
     content => $content,
+    owner   => $owner,
+    group   => $group,
     require => File[$dir],
     notify  => $service,
   }

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -134,6 +134,8 @@ class mesos::slave (
     value   => $work_dir,
     dir     => $conf_dir,
     file    => 'work_dir',
+    owner   => $owner,
+    group   => $group,
     service => Service['mesos-slave'],
     require => File[$conf_dir],
   }
@@ -156,6 +158,8 @@ class mesos::slave (
     mesos_hash_parser($merged_options, 'slave'),
     {
       dir     => $conf_dir,
+      owner   => $owner,
+      group   => $group,
       service => Service['mesos-slave'],
     }
   )
@@ -164,6 +168,8 @@ class mesos::slave (
     mesos_hash_parser($resources, 'resources'),
     {
       dir     => "${conf_dir}/resources",
+      owner   => $owner,
+      group   => $group,
       service => Service['mesos-slave'],
     }
   )
@@ -172,6 +178,8 @@ class mesos::slave (
     mesos_hash_parser($attributes, 'attributes'),
     {
       dir     => "${conf_dir}/attributes",
+      owner   => $owner,
+      group   => $group,
       service => Service['mesos-slave'],
     }
   )

--- a/spec/defines/property_spec.rb
+++ b/spec/defines/property_spec.rb
@@ -8,6 +8,8 @@ describe 'mesos::property', :type => :define do
     :value   => 'foo',
     :dir     => directory,
     :service => '',
+    :owner   => 'tester',
+    :group   => 'testers',
   }}
 
   it 'should create a property file' do
@@ -15,6 +17,8 @@ describe 'mesos::property', :type => :define do
         "#{directory}/#{title}"
       ).with_content(/^foo$/).with({
       'ensure'  => 'present',
+      'owner'   => 'tester',
+      'group'   => 'testers',
       })
   end
 


### PR DESCRIPTION
Without this, the `owner` and `group` parameters for the config are not much use as they only apply to some of the files.

I don't think many users are changing the owner/group from root but this at least makes it possible to do.