### PR TITLE
Ensure apt-get update runs before installing Mesos package

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -10,9 +10,7 @@ class mesos::repo(
   if $source {
     case $::osfamily {
       'Debian': {
-        if !defined(Class['apt']) {
-          class { 'apt': }
-        }
+        include apt
 
         $distro = downcase($::operatingsystem)
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -29,7 +29,10 @@ class mesos::repo(
                 'src' => false
               },
             }
-          include apt::update
+          anchor { 'mesos::repo::begin': } ->
+            Apt::Source['mesosphere'] ->
+            Class['apt::update'] ->
+          anchor { 'mesos::repo::end': }
           }
           default: {
             notify { "APT repository '${source}' is not supported for ${::osfamily}": }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -29,10 +29,10 @@ class mesos::repo(
                 'src' => false
               },
             }
-          anchor { 'mesos::repo::begin': } ->
-            Apt::Source['mesosphere'] ->
-            Class['apt::update'] ->
-          anchor { 'mesos::repo::end': }
+            anchor { 'mesos::repo::begin': } ->
+              Apt::Source['mesosphere'] ->
+              Class['apt::update'] ->
+            anchor { 'mesos::repo::end': }
           }
           default: {
             notify { "APT repository '${source}' is not supported for ${::osfamily}": }

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -23,6 +23,10 @@ describe 'mesos::repo', :type => :class do
      'include'  => {'src' => false}
     )}
 
+    it { should contain_anchor('mesos::repo::begin').that_comes_before('Apt::Source[mesosphere]') }
+    it { should contain_apt__source('mesosphere').that_comes_before('Class[apt::update]') }
+    it { should contain_class('apt::update').that_comes_before('Anchor[mesos::repo::end]') }
+
     context "undef source" do
       let(:params) {{
         :source => 'undef',


### PR DESCRIPTION
There were cases when the Mesos package was being installed before apt-get update had run, requiring the user to make the dependency explicit. This (hopefully) fixes that by cleaning up/correcting some of the apt stuff in `mesos::repo`.

* `include apt` shouldn't conflict with previously defined inclusions (no need to check if class defined)
* Doing `include apt` includes `apt::update`
* Doing `include apt::update` doesn't ensure any ordering of when the class is applied
* Use anchors to *contain* `Class['apt::update']` to ensure that if a resource requires `Class['mesos::repo']` by extension it also requires `Class['apt::update']`