### PR TITLE
Restart the mesos services on new mesos package installations

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -33,8 +33,10 @@ define mesos::service(
       hasrestart => true,
       enable     => $enable,
       provider   => $force_provider,
-      subscribe  => [ File['/etc/default/mesos'],
-        File["/etc/default/mesos-${name}"]
+      subscribe  => [
+        File['/etc/default/mesos'],
+        File["/etc/default/mesos-${name}"],
+        Package['mesos']
       ],
     }
   }


### PR DESCRIPTION
This PR make sure the mesos services are restarted on new mesos package installations, when you specify a new mesos version for example.

cc @deric 

Thanks
