### PR TITLE
mesos::property require/notify fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,18 +151,20 @@ class{'mesos::slave':
 As Mesos configuration flags changes with each version we don't provide directly a named parameter for each flag. `mesos::property` allows to create a parameter file or remove the file when `value` is left empty. e.g. configure value in `/etc/mesos/hostname`:
 
 ```puppet
-::mesos::property { 'hostname':
-  value => 'mesos.hostname.com',
-  dir   => '/etc/mesos'
+mesos::property { 'hostname':
+  value  => 'mesos.hostname.com',
+  dir    => '/etc/mesos-slave',
+  notify => Service['mesos-slave']
 }
 ```
 
 Remove this file simply set value to undef:
 
 ```puppet
-::mesos::property { 'hostname':
-  value => undef,
-  dir   => '/etc/mesos'
+mesos::property { 'hostname':
+  value  => undef,
+  dir    => '/etc/mesos-slave',
+  notify => Service['mesos-slave']
 }
 ```
 

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -101,17 +101,17 @@ class mesos::master(
     file    => 'work_dir',
     owner   => $owner,
     group   => $group,
-    service => Service['mesos-master'],
+    notify  => Service['mesos-master'],
     require => File[$conf_dir],
   }
 
   create_resources(mesos::property,
     mesos_hash_parser($merged_options, 'master'),
     {
-      dir     => $conf_dir,
-      owner   => $owner,
-      group   => $group,
-      service => Service['mesos-master'],
+      dir    => $conf_dir,
+      owner  => $owner,
+      group  => $group,
+      notify => Service['mesos-master'],
     }
   )
 

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -96,12 +96,12 @@ class mesos::master(
   # work_dir can't be specified via options,
   # we would get a duplicate declaration error
   mesos::property {'master_work_dir':
-    value   => $work_dir,
-    dir     => $conf_dir,
-    file    => 'work_dir',
-    owner   => $owner,
-    group   => $group,
-    notify  => Service['mesos-master'],
+    value  => $work_dir,
+    dir    => $conf_dir,
+    file   => 'work_dir',
+    owner  => $owner,
+    group  => $group,
+    notify => Service['mesos-master'],
   }
 
   create_resources(mesos::property,

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -102,7 +102,6 @@ class mesos::master(
     owner   => $owner,
     group   => $group,
     notify  => Service['mesos-master'],
-    require => File[$conf_dir],
   }
 
   create_resources(mesos::property,

--- a/manifests/property.pp
+++ b/manifests/property.pp
@@ -35,7 +35,6 @@ define mesos::property (
     content => $content,
     owner   => $owner,
     group   => $group,
-    require => File[$dir],
     notify  => $service,
   }
 

--- a/manifests/property.pp
+++ b/manifests/property.pp
@@ -4,7 +4,7 @@
 define mesos::property (
   $value,
   $dir,
-  $service, #service to be notified about property changes
+  $service = undef, #service to be notified about property changes
   $file = $title,
   $owner = 'root',
   $group = 'root',

--- a/manifests/property.pp
+++ b/manifests/property.pp
@@ -9,6 +9,9 @@ define mesos::property (
   $owner = 'root',
   $group = 'root',
 ) {
+  if $service != undef {
+    warning("\$service is deprecated and will be removed in the next major release, please use \$notify => ${service} instead")
+  }
 
   if is_bool($value) {
     $filename = $value ? {

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -137,7 +137,6 @@ class mesos::slave (
     owner   => $owner,
     group   => $group,
     notify  => Service['mesos-slave'],
-    require => File[$conf_dir],
   }
 
   file { $work_dir:

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -104,8 +104,8 @@ class mesos::slave (
   create_resources(mesos::property,
     mesos_hash_parser($cgroups, 'slave', 'cgroups'),
     {
-      dir     => $conf_dir,
-      service => Service['mesos-slave'],
+      dir    => $conf_dir,
+      notify => Service['mesos-slave'],
     }
   )
 
@@ -136,7 +136,7 @@ class mesos::slave (
     file    => 'work_dir',
     owner   => $owner,
     group   => $group,
-    service => Service['mesos-slave'],
+    notify  => Service['mesos-slave'],
     require => File[$conf_dir],
   }
 
@@ -157,30 +157,30 @@ class mesos::slave (
   create_resources(mesos::property,
     mesos_hash_parser($merged_options, 'slave'),
     {
-      dir     => $conf_dir,
-      owner   => $owner,
-      group   => $group,
-      service => Service['mesos-slave'],
+      dir    => $conf_dir,
+      owner  => $owner,
+      group  => $group,
+      notify => Service['mesos-slave'],
     }
   )
 
   create_resources(mesos::property,
     mesos_hash_parser($resources, 'resources'),
     {
-      dir     => "${conf_dir}/resources",
-      owner   => $owner,
-      group   => $group,
-      service => Service['mesos-slave'],
+      dir    => "${conf_dir}/resources",
+      owner  => $owner,
+      group  => $group,
+      notify => Service['mesos-slave'],
     }
   )
 
   create_resources(mesos::property,
     mesos_hash_parser($attributes, 'attributes'),
     {
-      dir     => "${conf_dir}/attributes",
-      owner   => $owner,
-      group   => $group,
-      service => Service['mesos-slave'],
+      dir    => "${conf_dir}/attributes",
+      owner  => $owner,
+      group  => $group,
+      notify => Service['mesos-slave'],
     }
   )
 

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -131,12 +131,12 @@ class mesos::slave (
   # work_dir can't be specified via options,
   # we would get a duplicate declaration error
   mesos::property {'slave_work_dir':
-    value   => $work_dir,
-    dir     => $conf_dir,
-    file    => 'work_dir',
-    owner   => $owner,
-    group   => $group,
-    notify  => Service['mesos-slave'],
+    value  => $work_dir,
+    dir    => $conf_dir,
+    file   => 'work_dir',
+    owner  => $owner,
+    group  => $group,
+    notify => Service['mesos-slave'],
   }
 
   file { $work_dir:

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -147,6 +147,15 @@ describe 'mesos::master', :type => :class do
       'owner'   => owner,
       'group'   => group,
     }) }
+
+    it do
+      should contain_mesos__property('master_work_dir').with({
+        'owner' => owner,
+        'group' => group,
+        'dir'   => conf,
+        'value' => work_dir,
+      }).that_requires("File[#{conf}]")
+    end
   end
 
   context 'support boolean flags' do

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -142,11 +142,13 @@ describe 'mesos::master', :type => :class do
     }}
 
 
-    it { should contain_file(work_dir).with({
-      'ensure'  => 'directory',
-      'owner'   => owner,
-      'group'   => group,
-    }) }
+    it do
+      should contain_file(work_dir).with({
+        'ensure'  => 'directory',
+        'owner'   => owner,
+        'group'   => group,
+      })
+    end
 
     it do
       should contain_mesos__property('master_work_dir').with({
@@ -159,7 +161,7 @@ describe 'mesos::master', :type => :class do
 
     it do
       should contain_file("#{conf}/work_dir")
-        .with_content(/\/var\/lib\/mesos/)
+        .with_content(work_dir)
         .that_requires("File[#{conf}]")
     end
   end

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -154,7 +154,13 @@ describe 'mesos::master', :type => :class do
         'group' => group,
         'dir'   => conf,
         'value' => work_dir,
-      }).that_requires("File[#{conf}]")
+      })
+    end
+
+    it do
+      should contain_file("#{conf}/work_dir")
+        .with_content(/\/var\/lib\/mesos/)
+        .that_requires("File[#{conf}]")
     end
   end
 

--- a/spec/classes/slave_spec.rb
+++ b/spec/classes/slave_spec.rb
@@ -302,6 +302,14 @@ describe 'mesos::slave', :type => :class do
     }}
 
     it do
+      should contain_file(work_dir).with({
+        'ensure'  => 'directory',
+        'owner'   => owner,
+        'group'   => group,
+      })
+    end
+
+    it do
       should contain_mesos__property('slave_work_dir').with({
         'owner' => owner,
         'group' => group,
@@ -312,15 +320,9 @@ describe 'mesos::slave', :type => :class do
 
     it do
       should contain_file("#{conf}/work_dir")
-        .with_content(/\/tmp\/mesos/)
+        .with_content(work_dir)
         .that_requires("File[#{conf}]")
     end
-
-    it { should contain_file(work_dir).with({
-      'ensure'  => 'directory',
-      'owner'   => owner,
-      'group'   => group,
-    }) }
   end
 
   context 'support boolean flags' do

--- a/spec/classes/slave_spec.rb
+++ b/spec/classes/slave_spec.rb
@@ -307,12 +307,14 @@ describe 'mesos::slave', :type => :class do
         'group' => group,
         'dir'   => conf,
         'value' => work_dir,
-      }).that_requires("File[#{conf}]")
+      })
     end
 
-    it { should contain_file(
-      "#{conf}/work_dir"
-    ).with_content(/\/tmp\/mesos/) }
+    it do
+      should contain_file("#{conf}/work_dir")
+        .with_content(/\/tmp\/mesos/)
+        .that_requires("File[#{conf}]")
+    end
 
     it { should contain_file(work_dir).with({
       'ensure'  => 'directory',

--- a/spec/classes/slave_spec.rb
+++ b/spec/classes/slave_spec.rb
@@ -301,6 +301,15 @@ describe 'mesos::slave', :type => :class do
       :group    => group,
     }}
 
+    it do
+      should contain_mesos__property('slave_work_dir').with({
+        'owner' => owner,
+        'group' => group,
+        'dir'   => conf,
+        'value' => work_dir,
+      }).that_requires("File[#{conf}]")
+    end
+
     it { should contain_file(
       "#{conf}/work_dir"
     ).with_content(/\/tmp\/mesos/) }

--- a/spec/defines/property_spec.rb
+++ b/spec/defines/property_spec.rb
@@ -12,6 +12,8 @@ describe 'mesos::property', :type => :define do
     :group   => 'testers',
   }}
 
+  it { should compile }
+
   it 'should create a property file' do
       should contain_file(
         "#{directory}/#{title}"

--- a/spec/defines/property_spec.rb
+++ b/spec/defines/property_spec.rb
@@ -38,6 +38,21 @@ describe 'mesos::property', :type => :define do
     end
   end
 
+  context 'with an undef value' do
+    let(:params) {{
+      :value   => :undef,
+      :dir     => directory,
+    }}
+
+    it 'should not contain a property file' do
+        should contain_file(
+          "#{directory}/#{title}"
+        ).with({
+        'ensure'  => 'absent',
+        })
+    end
+  end
+
   context 'with an empty array value' do
     let(:params) {{
       :value   => [], # TODO this is not really meaningful value

--- a/spec/defines/property_spec.rb
+++ b/spec/defines/property_spec.rb
@@ -7,7 +7,6 @@ describe 'mesos::property', :type => :define do
   let(:params) {{
     :value   => 'foo',
     :dir     => directory,
-    :service => '',
     :owner   => 'tester',
     :group   => 'testers',
   }}
@@ -28,7 +27,6 @@ describe 'mesos::property', :type => :define do
     let(:params) {{
       :value   => '',
       :dir     => directory,
-      :service => '',
     }}
 
     it 'should not contain a property file' do
@@ -44,7 +42,6 @@ describe 'mesos::property', :type => :define do
     let(:params) {{
       :value   => [], # TODO this is not really meaningful value
       :dir     => directory,
-      :service => '',
     }}
 
     it 'should not contain a property file' do
@@ -60,7 +57,6 @@ describe 'mesos::property', :type => :define do
     let(:params) {{
       :value   => true, # TODO this is not really meaningful value
       :dir     => directory,
-      :service => '',
     }}
 
     it 'should contain a property file' do
@@ -76,7 +72,6 @@ describe 'mesos::property', :type => :define do
     let(:params) {{
       :value   => false, # TODO this is not really meaningful value
       :dir     => directory,
-      :service => '',
     }}
 
     it 'should contain a "no-property" file' do
@@ -92,7 +87,6 @@ describe 'mesos::property', :type => :define do
     let(:params) {{
       :value   => 314,
       :dir     => directory,
-      :service => '',
     }}
 
     it 'should contain a property file' do
@@ -108,7 +102,6 @@ describe 'mesos::property', :type => :define do
     let(:params) {{
       :value   => 3.14,
       :dir     => directory,
-      :service => '',
     }}
 
     it 'should contain a property file' do


### PR DESCRIPTION
The `require` and `notify` parameters of the files created by `mesos::property` are not currently being tested and if you try to test them then things break...

Two observations with the `file` resource in `mesos::property`:
* The `require` is not necessary as Puppet will autorequire parent directories.
* The `notify => $service` is not necessary either. If we use `notify` on the `mesos::property` resource rather it does the same thing... if any of the resources in the defined type refresh, the defined type itself will refresh and notify other resources.

This PR makes changes one-by-one to:
* Remove the `require` on the file in `mesos::property`.
* Default the `service` parameter in `mesos::property` to `undef` so that the parameter is no longer required.
* Deprecate the `service` parameter. Warn users to rather use `notify`. Use `notify` internally.
* Test updates

These changes are not really fixing a major problem or adding a major feature but cleans up the `mesos::property` resource a bit. We use the `mesos::property` resource in our module to manage Marathon and so I have been discovering some of the quirks with the type.