### PR TITLE
Fix dependencies when setting mesos::master/slave::conf_file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,7 @@ class mesos::config(
   $log_dir        = undef,
   $ulimit         = 8192,
   $conf_dir       = '/etc/mesos',
+  $conf_file      = '/etc/default/mesos',
   $manage_zk_file = true,
   $owner          = 'root',
   $group          = 'root',
@@ -38,7 +39,7 @@ class mesos::config(
     group  => $group,
   }
 
-  file { '/etc/default/mesos':
+  file { $conf_file:
     ensure  => 'present',
     content => template('mesos/default.erb'),
     owner   => $owner,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@ class mesos(
   # TODO: currently not used
   $log_dir        = '/var/log/mesos',
   $conf_dir       = '/etc/mesos',
+  $conf_file      = '/etc/default/mesos',
   $manage_zk_file = true,
   $manage_service = true,
   # e.g. zk://localhost:2181/mesos
@@ -63,6 +64,7 @@ class mesos(
   class {'mesos::config':
     log_dir        => $log_dir,
     conf_dir       => $conf_dir,
+    conf_file      => $conf_file,
     manage_zk_file => $manage_zk_file,
     owner          => $owner,
     group          => $group,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,6 +15,8 @@ define mesos::service(
   $manage         = true,
 ) {
 
+  include ::mesos
+
   if $manage {
     if $enable {
       $ensure_service = 'running'
@@ -34,8 +36,7 @@ define mesos::service(
       enable     => $enable,
       provider   => $force_provider,
       subscribe  => [
-        File['/etc/default/mesos'],
-        File["/etc/default/mesos-${name}"],
+        File[$mesos::conf_file],
         Package['mesos']
       ],
     }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -32,6 +32,17 @@ describe 'mesos::config', :type => :class do
     ).with_content(/ULIMIT="-n 8192"/)
   end
 
+  context 'conf_file' do
+    let(:conf_file) { '/etc/sysconfig/mesos' }
+    let(:params){{
+        :conf_file => conf_file,
+    }}
+
+    it do
+      should contain_file(conf_file)
+    end
+  end
+
   context 'setting ulimit' do
     let(:params){{
       :ulimit => 16384,


### PR DESCRIPTION
* Allow writing mesos::conf_file to some different place than /etc/default/mesos
* The dependencies to mesos::master/slave::conf_file is already handled in master.pp/slave.pp