### PR TITLE
Add ensure parameter to mesos::property

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ class{'mesos::slave':
 
 ## File based configuration
 
-As Mesos configuration flags changes with each version we don't provide directly a named parameter for each flag. `mesos::property` allows to create a parameter file or remove the file when `value` is left empty. e.g. configure value in `/etc/mesos/hostname`:
+As Mesos configuration flags changes with each version we don't provide directly a named parameter for each flag. `mesos::property` allows to create a parameter file. e.g. configure value in `/etc/mesos-slave/hostname`:
 
 ```puppet
 mesos::property { 'hostname':
@@ -158,11 +158,11 @@ mesos::property { 'hostname':
 }
 ```
 
-Remove this file simply set value to undef:
+Remove this file simply use the `ensure` parameter:
 
 ```puppet
 mesos::property { 'hostname':
-  value  => undef,
+  ensure => absent,
   dir    => '/etc/mesos-slave',
   notify => Service['mesos-slave']
 }

--- a/manifests/property.pp
+++ b/manifests/property.pp
@@ -14,6 +14,16 @@ define mesos::property (
     warning("\$service is deprecated and will be removed in the next major release, please use \$notify => ${service} instead")
   }
 
+  case $ensure {
+    present: { }
+    file: { }
+    absent: { }
+    undef: { }
+    default: {
+      fail("\$ensure must be one of 'present', 'file', 'absent', or undef, not '${ensure}'")
+    }
+  }
+
   if is_bool($value) {
     $filename = $value ? {
       true => "${dir}/?${file}",

--- a/manifests/property.pp
+++ b/manifests/property.pp
@@ -34,9 +34,11 @@ define mesos::property (
   } else {
     $filename = "${dir}/${file}"
     if $ensure == undef {
-      $real_ensure = empty($value) ? {
-        true  => absent,
-        false => present,
+      if empty($value) {
+        warning("Setting \$value to an empty value is deprecated and will be removed in the next major release, please use \$ensure => absent instead")
+        $real_ensure = absent
+      } else {
+        $real_ensure = present
       }
     } else {
       $real_ensure = $ensure

--- a/manifests/property.pp
+++ b/manifests/property.pp
@@ -4,6 +4,7 @@
 define mesos::property (
   $value,
   $dir,
+  $ensure = undef,
   $service = undef, #service to be notified about property changes
   $file = $title,
   $owner = 'root',
@@ -18,23 +19,33 @@ define mesos::property (
       true => "${dir}/?${file}",
       false => "${dir}/?no-${file}",
     }
-    $ensure = 'present'
+    $real_ensure = $ensure ? {
+      undef   => 'present',
+      default => $ensure,
+    }
     $content = ''
   } elsif is_numeric($value) {
     $filename = "${dir}/${file}"
-    $ensure = 'present'
+    $real_ensure = $ensure ? {
+      undef   => 'present',
+      default => $ensure,
+    }
     $content = "${value}"
   } else {
     $filename = "${dir}/${file}"
-    $ensure = empty($value) ? {
-      true  => absent,
-      false => present,
+    if $ensure == undef {
+      $real_ensure = empty($value) ? {
+        true  => absent,
+        false => present,
+      }
+    } else {
+      $real_ensure = $ensure
     }
     $content = $value
   }
 
   file { $filename:
-    ensure  => $ensure,
+    ensure  => $real_ensure,
     content => $content,
     owner   => $owner,
     group   => $group,

--- a/manifests/property.pp
+++ b/manifests/property.pp
@@ -15,9 +15,9 @@ define mesos::property (
   }
 
   case $ensure {
-    present: { }
-    file: { }
-    absent: { }
+    present, file, absent: {
+      $real_ensure = $ensure
+    }
     undef: { }
     default: {
       fail("\$ensure must be one of 'present', 'file', 'absent', or undef, not '${ensure}'")
@@ -29,16 +29,14 @@ define mesos::property (
       true => "${dir}/?${file}",
       false => "${dir}/?no-${file}",
     }
-    $real_ensure = $ensure ? {
-      undef   => 'present',
-      default => $ensure,
+    if $ensure == undef {
+      $real_ensure = present
     }
     $content = ''
   } elsif is_numeric($value) {
     $filename = "${dir}/${file}"
-    $real_ensure = $ensure ? {
-      undef   => 'present',
-      default => $ensure,
+    if $ensure == undef {
+      $real_ensure = present
     }
     $content = "${value}"
   } else {
@@ -50,8 +48,6 @@ define mesos::property (
       } else {
         $real_ensure = present
       }
-    } else {
-      $real_ensure = $ensure
     }
     $content = $value
   }

--- a/spec/defines/property_spec.rb
+++ b/spec/defines/property_spec.rb
@@ -127,4 +127,70 @@ describe 'mesos::property', :type => :define do
       })
     end
   end
+
+  context 'ensure is set' do
+    describe 'when ensure is present and the value is empty' do
+      let(:params) {{
+        :ensure => 'present',
+        :value  => '',
+        :dir    => directory,
+      }}
+
+      it 'should contain a property file' do
+          should contain_file(
+            "#{directory}/#{title}"
+          ).with({
+          'ensure'  => 'present',
+          })
+      end
+    end
+
+    describe 'when ensure is absent and the value is empty' do
+      let(:params) {{
+        :ensure => 'absent',
+        :value  => '',
+        :dir    => directory,
+      }}
+
+      it 'should not contain a property file' do
+          should contain_file(
+            "#{directory}/#{title}"
+          ).with({
+          'ensure'  => 'absent',
+          })
+      end
+    end
+
+    describe 'when ensure is absent and the value is a boolean' do
+      let(:params) {{
+        :ensure => 'absent',
+        :value  => false,
+        :dir    => directory,
+      }}
+
+      it 'should not contain a property file' do
+          should contain_file(
+            "#{directory}/?no-#{title}"
+          ).with({
+          'ensure'  => 'absent',
+          })
+      end
+    end
+
+    describe 'when ensure is absent and the value is numeric' do
+      let(:params) {{
+        :ensure => 'absent',
+        :value  => 123,
+        :dir    => directory,
+      }}
+
+      it 'should not contain a property file' do
+          should contain_file(
+            "#{directory}/#{title}"
+          ).with({
+          'ensure'  => 'absent',
+          })
+      end
+    end
+  end
 end

--- a/spec/defines/property_spec.rb
+++ b/spec/defines/property_spec.rb
@@ -145,6 +145,22 @@ describe 'mesos::property', :type => :define do
       end
     end
 
+    describe 'when ensure is file and the value is empty' do
+      let(:params) {{
+        :ensure => 'file',
+        :value  => '',
+        :dir    => directory,
+      }}
+
+      it 'should contain a property file' do
+          should contain_file(
+            "#{directory}/#{title}"
+          ).with({
+          'ensure'  => 'file',
+          })
+      end
+    end
+
     describe 'when ensure is absent and the value is empty' do
       let(:params) {{
         :ensure => 'absent',
@@ -191,6 +207,16 @@ describe 'mesos::property', :type => :define do
           'ensure'  => 'absent',
           })
       end
+    end
+
+    describe 'when ensure is directory' do
+      let(:params) {{
+        :ensure => 'directory',
+        :value  => 'test',
+        :dir    => directory,
+      }}
+
+      it { should raise_error(/\$ensure must be .* not 'directory'/) }
     end
   end
 end


### PR DESCRIPTION
The current method of setting `value` to an empty value for `mesos::property` resources in order to remove the created file has the limitation that it doesn't work for boolean values. Also, it's not the most intuitive way of doing things.

This PR:
* Introduces an `ensure` parameter for `mesos::property` that gets passed through to the underlying `file` resource if it is set.
* Deprecates the old method of setting `value` to an empty value.
* Maintains the existing behaviour if `ensure` is not set.