### PR TITLE
Make mesos services subscribe to configs

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -175,7 +175,7 @@ class mesos::master(
     enable         => $enable,
     force_provider => $force_provider,
     manage         => $manage_service,
-    require        => File[$conf_file],
+    subscribe      => File[$conf_file],
   }
 
   if (!defined(Class['mesos::slave']) and $single_role) {

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -245,7 +245,7 @@ class mesos::slave (
     enable         => $enable,
     force_provider => $force_provider,
     manage         => $manage_service,
-    require        => File[$conf_file],
+    subscribe      => File[$conf_file],
   }
 
   if (!defined(Class['mesos::master']) and $single_role) {


### PR DESCRIPTION
* master and slave services should subscribe to
  /etc/defaults/mesos-master and /etc/defaults/mesos-slave
  instead of just requirering them. So the services will
  restart if these files are changed.