### PR TITLE
Add file:// to credentials option

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -66,7 +66,7 @@ class mesos::master(
   }
 
   if (!empty($credentials)) {
-    $credentials_options = {'credentials' => $credentials_file}
+    $credentials_options = {'credentials' => "file://${credentials_file}"}
     $credentials_content = inline_template("<%= require 'json'; {:credentials => @credentials}.to_json %>")
     $credentials_ensure = file
   } else {

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -270,7 +270,7 @@ describe 'mesos::master', :type => :class do
         should contain_mesos__property(
                    'master_credentials'
                ).with({
-                          'value' => '/etc/mesos/master-credentials',
+                          'value' => 'file:///etc/mesos/master-credentials',
                       })
       end
 


### PR DESCRIPTION
Mesos master said: "Specifying an absolute filename
to read a command line option out of without using
'file:// is deprecated and will be removed in a future
release. Simply adding 'file://' to the beginning of
the path should eliminate this warning."