### PR TITLE
options should not be prepended with 'master' or 'slave'.

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -135,7 +135,7 @@ class mesos::master(
   }
 
   create_resources(mesos::property,
-    mesos_hash_parser($merged_options, 'master'),
+    mesos_hash_parser($merged_options),
     {
       dir    => $conf_dir,
       owner  => $owner,

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -189,7 +189,7 @@ class mesos::slave (
   }
 
   create_resources(mesos::property,
-    mesos_hash_parser($merged_options, 'slave'),
+    mesos_hash_parser($merged_options),
     {
       dir    => $conf_dir,
       owner  => $owner,


### PR DESCRIPTION
fixes issue reported in #66 where options stored in /etc/mesos-master and /etc/mesos-slave were being prepended with `master_` and `slave_` which was breaking functionality with `/usr/bin/mesos-init-wrapper` because it sends options as `--master_hostname` as opposed to `hostname` for instance. 

i'm not sure how or why this is not affecting any other users of this module, so this code may be irrelevant and I may just be looking for clarification on why my setup is not working out of the box.   