### PR TITLE
Refactor mesos::property and its spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg/*
 Gemfile.lock
 Puppetfile.lock
 vendor/
+.idea

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,4 @@
 --format documentation
 --color
---pattern "spec/*/*_spec.rb"
+--pattern 'spec/{classes,defines,unit,functions,hosts,integration,types}/**/*_spec.rb'
 #--backtrace

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,14 @@
+= TODO
+
+* When the slave configuration is changed the file
+  */tmp/mesos/meta/slaves/latest* should be removed.
+  Or, even better, the slave should be started with *--recover=cleanup*
+  and, when all executors have been cleaned, restarted back with
+  *--recover=reconnect*. We should invent a way to do this to
+  prevent a slave being unable to start after online reconfiguration.
+* Move all default values to the params class. Inherit all classes from
+  the params class and pass custom values from the main class.
+* Rename all parameters to the recommended style *entity_property*
+  i.e. *config_file_path*, *config_file_mode*.
+* Introduce some acceptance testing
+* Rewrite specs to the modern syntax

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,5 @@
+class mesos::params {
+  $config_file_owner = 'root'
+  $config_file_group = 'root'
+  $config_file_mode  = '0644'
+}

--- a/manifests/property.pp
+++ b/manifests/property.pp
@@ -1,62 +1,101 @@
-# Used for storing configuration in
-# directory structure
-
+# == Define: mesos::property
+#
+# This definition can set one of the option files in the mesos configuration
+# directories. These files will be used as command line options by the
+# mesos services.
+#
+# === Examples
+#
+# mesos::property { 'my_option' :
+#   value => 'my_value',
+#   dir   => '/etc/my_service/conf,
+# }
+#
+# === Parameters
+#
+# [*value*]
+# (required) The value of this option. If this parameter is boolean, the
+# predicate option file will be created.
+#
+# [*file*]
+# If this parameter is set, this value will be used instead of the definition
+# title as the option name.
+#
+# [*dir*]
+# (required) The root directory of this options. Should be set to the service
+# configuration directory.
+#
+# [*ensure*]
+# Create or remove the option. Can be one of present, absent, file.
+# Default: present
+#
+# [*owner*]
+# Which system yser should own this file?
+# Default: root
+#
+# [*group*]
+# What system groups should this file belong?
+# Default: root
+#
+# [*mode*]
+# What access mode should this file have?
+# Default: 0644
+#
 define mesos::property (
   $dir,
-  $value = undef,
-  $ensure = undef,
-  $service = undef, #service to be notified about property changes
-  $file = $title,
-  $owner = 'root',
-  $group = 'root',
+  $value   = undef,
+  $ensure  = 'present',
+  $file    = undef,
+  $service = undef,
+  $owner   = undef,
+  $group   = undef,
+  $mode    = undef,
 ) {
-  if $service != undef {
-    warning("\$service is deprecated and will be removed in the next major release, please use \$notify => ${service} instead")
+  include ::mesos::params
+  validate_absolute_path($dir)
+
+  if ! ($ensure in ['present', 'absent', 'file']) {
+    fail("\$ensure must be one of 'present', 'file', 'absent'!")
   }
 
-  case $ensure {
-    present, file, absent: {
-      $real_ensure = $ensure
-    }
-    undef: { }
-    default: {
-      fail("\$ensure must be one of 'present', 'file', 'absent', or undef, not '${ensure}'")
-    }
+  if $service {
+    fail("\$service is deprecated and will be removed in the next major release, please use \$notify => ${service} instead")
   }
+
+  $file_name  = pick($file, $name)
+  $file_owner = pick($owner, $mesos::params::config_file_owner)
+  $file_group = pick($group, $mesos::params::config_file_group)
+  $file_mode  = pick($mode,  $mesos::params::config_file_mode)
 
   if is_bool($value) {
-    $filename = $value ? {
-      true => "${dir}/?${file}",
-      false => "${dir}/?no-${file}",
+    if $value {
+      $file_path = "${dir}/?${file_name}"
+    } else {
+      $file_path = "${dir}/?no-${file_name}"
     }
-    if $ensure == undef {
-      $real_ensure = present
-    }
-    $content = ''
-  } elsif is_numeric($value) {
-    $filename = "${dir}/${file}"
-    if $ensure == undef {
-      $real_ensure = present
-    }
-    $content = "${value}"
+    $file_content = ''
+    $file_ensure = $ensure
   } else {
-    $filename = "${dir}/${file}"
-    if $ensure == undef {
-      if empty($value) {
-        warning("Setting \$value to an empty value is deprecated and will be removed in the next major release, please use \$ensure => absent instead")
-        $real_ensure = absent
+    $file_path = "${dir}/${file_name}"
+    if empty($value) {
+      warning("Setting \$value to an empty value is deprecated and will be removed in the next major release, please use \$ensure => absent instead")
+      if $ensure == 'file' {
+        $file_ensure = 'present'
       } else {
-        $real_ensure = present
+        $file_ensure = 'absent'
       }
+    } else {
+      $file_ensure = $ensure
     }
-    $content = $value
+    $file_content = "${value}\n"
   }
 
-  file { $filename:
-    ensure  => $real_ensure,
-    content => $content,
-    owner   => $owner,
-    group   => $group,
+  file { $file_path :
+    ensure  => $file_ensure,
+    content => $file_content,
+    owner   => $file_owner,
+    group   => $file_group,
+    mode    => $file_mode,
     notify  => $service,
   }
 

--- a/spec/classes/cli_spec.rb
+++ b/spec/classes/cli_spec.rb
@@ -10,6 +10,10 @@ describe 'mesos::cli', :type => :class do
     :group    => group,
   }}
 
+  before(:each) do
+    puppet_debug_override
+  end
+
   it { should contain_package('python-pip') }
   it { should contain_class('mesos::cli') }
   it { should contain_package('mesos.cli').with({'provider' => 'pip'}) }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -12,6 +12,10 @@ describe 'mesos::config', :type => :class do
     :group    => group,
   }}
 
+  before(:each) do
+    puppet_debug_override
+  end
+
   it { should contain_file('/etc/default/mesos').with({
     'ensure'  => 'present',
     'owner'   => owner,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,6 +8,10 @@ describe 'mesos', :type => :class do
       :ensure => version
     }}
 
+    before(:each) do
+      puppet_debug_override
+    end
+
     it { should contain_package('mesos').with({
       'ensure' => version
     }) }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -8,6 +8,10 @@ describe 'mesos::install', :type => :class do
       :ensure => version
     }}
 
+    before(:each) do
+      puppet_debug_override
+    end
+
     it { should contain_package('mesos').with({
       'ensure' => version
     }) }

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -12,6 +12,10 @@ describe 'mesos::master', :type => :class do
     :group    => group,
   }}
 
+   before(:each) do
+     puppet_debug_override
+   end
+
   it { is_expected.to contain_package('mesos') }
   it { is_expected.to contain_class('mesos::master') }
   it { is_expected.to contain_service('mesos-master').with(
@@ -162,7 +166,7 @@ describe 'mesos::master', :type => :class do
 
     it do
       should contain_file("#{conf}/work_dir")
-        .with_content(work_dir)
+        .with_content(work_dir + "\n")
         .that_requires("File[#{conf}]")
     end
   end

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -15,6 +15,10 @@ describe 'mesos::repo', :type => :class do
       :puppetversion => puppet,
     }}
 
+    before(:each) do
+      puppet_debug_override
+    end
+
     it { should contain_apt__source('mesosphere').with(
      'location' => "http://repos.mesosphere.io/#{operatingsystem.downcase}",
      'repos'    => 'main',

--- a/spec/classes/slave_spec.rb
+++ b/spec/classes/slave_spec.rb
@@ -12,6 +12,10 @@ describe 'mesos::slave', :type => :class do
     :group    => group,
   }}
 
+  before(:each) do
+    puppet_debug_override
+  end
+
   it { should contain_package('mesos') }
   it { should contain_service('mesos-slave').with(
       :ensure => 'running',
@@ -253,23 +257,19 @@ describe 'mesos::slave', :type => :class do
     ).with_content(/^2048$/)}
   end
 
-  context 'custom ipaddress fact' do
-    let(:facts) {{
-      :ipaddress_eth0 => '192.168.1.2',
-    }}
-
+  context 'custom listen_address value' do
     let(:params){{
       :conf_dir => conf,
       :owner    => owner,
       :group    => group,
-      :listen_address => '$::ipaddress_eth0'
+      :listen_address => '192.168.1.2',
     }}
 
     # fact is not evaluated in test with newer puppet (or rspec)
-    xit 'has ip address from system fact' do
+    it 'has ip address from system fact' do
       should contain_file(
         slave_file
-      ).with_content(/^IP="192.168.1.2"$/)
+      ).with_content(/IP="192\.168\.1\.2"$/)
     end
   end
 
@@ -329,7 +329,7 @@ describe 'mesos::slave', :type => :class do
 
     it do
       should contain_file("#{conf}/work_dir")
-        .with_content(work_dir)
+        .with_content(work_dir + "\n")
         .that_requires("File[#{conf}]")
     end
   end
@@ -337,7 +337,7 @@ describe 'mesos::slave', :type => :class do
   context 'common slave config' do
     let(:params){{
       :zookeeper      => 'zk://192.168.1.1:2181,192.168.1.2:2181,192.168.1.3:2181/mesos',
-      :listen_address => "$::ipaddress",
+      :listen_address => '192.168.1.1',
       :attributes     => {
         'env' => 'production',
       },

--- a/spec/defines/property_spec.rb
+++ b/spec/defines/property_spec.rb
@@ -4,219 +4,290 @@ describe 'mesos::property', :type => :define do
   let(:title) { 'some-property' }
   let(:directory) { '/tmp/mesos-conf' }
 
-  let(:params) {{
-    :value   => 'foo',
-    :dir     => directory,
-    :owner   => 'tester',
-    :group   => 'testers',
-  }}
-
-  it { should compile }
-
-  it 'should create a property file' do
-      should contain_file(
-        "#{directory}/#{title}"
-      ).with_content(/^foo$/).with({
-      'ensure'  => 'present',
-      'owner'   => 'tester',
-      'group'   => 'testers',
-      })
+  before(:each) do
+    puppet_debug_override
   end
 
-  context 'with an empty string value' do
-    let(:params) {{
-      :value   => '',
-      :dir     => directory,
-    }}
+  context 'with a string value' do
+    let(:params) do
+      {
+          :value => 'foo',
+          :dir => directory,
+      }
+    end
 
-    it 'should not contain a property file' do
-        should contain_file(
-          "#{directory}/#{title}"
-        ).with({
-        'ensure'  => 'absent',
-        })
+    it { is_expected.to compile.with_all_deps }
+
+    it do
+      parameters = {
+          :ensure => 'present',
+          :content => "foo\n",
+      }
+      is_expected.to contain_file("#{directory}/#{title}").with(parameters)
     end
   end
 
-  context 'with an undef value' do
-    let(:params) {{
-      :value   => :undef,
-      :dir     => directory,
-    }}
+  context 'with an empty value' do
+    let(:params) do
+      {
+          :value => '',
+          :dir => directory,
+      }
+    end
 
-    it 'should not contain a property file' do
-        should contain_file(
-          "#{directory}/#{title}"
-        ).with({
-        'ensure'  => 'absent',
-        })
+    it { is_expected.to compile.with_all_deps }
+
+    it 'should remove a property file' do
+      is_expected.to contain_file("#{directory}/#{title}").with_ensure('absent')
     end
   end
 
-  context 'with an empty array value' do
-    let(:params) {{
-      :value   => [], # TODO this is not really meaningful value
-      :dir     => directory,
-    }}
+  context 'with the :undef value' do
+    let(:params) do
+      {
+          :value => :undef,
+          :dir => directory,
+      }
+    end
 
-    it 'should not contain a property file' do
-        should contain_file(
-          "#{directory}/#{title}"
-        ).with({
-        'ensure'  => 'absent',
-        })
+    it { is_expected.to compile.with_all_deps }
+
+    it 'should remove the property file' do
+      is_expected.to contain_file("#{directory}/#{title}").with_ensure('absent')
+    end
+  end
+
+
+  context 'without a defined value or dir' do
+    let(:params) do
+      {}
+    end
+
+    it 'should fail with an error' do
+      expect do
+        is_expected.to compile.with_all_deps
+      end.to raise_error /dir/
     end
   end
 
   context 'with a boolean (true) value' do
-    let(:params) {{
-      :value   => true, # TODO this is not really meaningful value
-      :dir     => directory,
-    }}
+    let(:params) do
+      {
+          :value => true,
+          :dir => directory,
+      }
+    end
 
-    it 'should contain a property file' do
-        should contain_file(
-          "#{directory}/?#{title}"
-        ).with({
-        'ensure'  => 'present',
-        })
+    it { is_expected.to compile.with_all_deps }
+
+    it 'should contain a positive "predicate" file' do
+      parameters = {
+          :ensure => 'present',
+          :content => '',
+      }
+      is_expected.to contain_file("#{directory}/?#{title}").with(parameters)
     end
   end
 
   context 'with a boolean (false) value' do
-    let(:params) {{
-      :value   => false, # TODO this is not really meaningful value
-      :dir     => directory,
-    }}
+    let(:params) do
+      {
+          :value => false,
+          :dir => directory,
+      }
+    end
 
-    it 'should contain a "no-property" file' do
-        should contain_file(
-          "#{directory}/?no-#{title}"
-        ).with({
-        'ensure'  => 'present',
-        })
+    it { is_expected.to compile.with_all_deps }
+
+    it 'should contain a negative "predicate" file' do
+      parameters = {
+          :ensure => 'present',
+          :content => '',
+      }
+      is_expected.to contain_file("#{directory}/?no-#{title}").with(parameters)
     end
   end
 
-  context 'with a integer value' do
-    let(:params) {{
-      :value   => 314,
-      :dir     => directory,
-    }}
+  context 'with an integer value' do
+    let(:params) do
+      {
+          :value => 123,
+          :dir => directory,
+      }
+    end
 
-    it 'should contain a property file' do
-        should contain_file(
-          "#{directory}/#{title}"
-        ).with_content(/^314$/).with({
-      'ensure'  => 'present',
-      })
+    it { is_expected.to compile.with_all_deps }
+
+    it 'should create a property file with the value' do
+      parameters = {
+          :ensure => 'present',
+          :content => "123\n",
+      }
+      is_expected.to contain_file("#{directory}/#{title}").with(parameters)
     end
   end
 
   context 'with a float value' do
-    let(:params) {{
-      :value   => 3.14,
-      :dir     => directory,
-    }}
+    let(:params) do
+      {
+          :value => 3.14,
+          :dir => directory,
+      }
+    end
 
-    it 'should contain a property file' do
-        should contain_file(
-          "#{directory}/#{title}"
-        ).with_content(/^3.14$/).with({
-      'ensure'  => 'present',
-      })
+    it { is_expected.to compile.with_all_deps }
+
+    it 'should create a property file with the value' do
+      parameters = {
+          :ensure => 'present',
+          :content => "3.14\n",
+      }
+      is_expected.to contain_file("#{directory}/#{title}").with(parameters)
     end
   end
 
-  context 'ensure is set' do
-    describe 'when ensure is present and the value is empty' do
-      let(:params) {{
-        :ensure => 'present',
-        :value  => '',
-        :dir    => directory,
-      }}
-
-      it 'should contain a property file' do
-          should contain_file(
-            "#{directory}/#{title}"
-          ).with({
-          'ensure'  => 'present',
-          })
-      end
+  context 'ensure is set to absent' do
+    let(:params) do
+      {
+          :ensure => 'absent',
+          :value => 'foo',
+          :dir => directory,
+      }
     end
 
-    describe 'when ensure is file and the value is empty' do
-      let(:params) {{
-        :ensure => 'file',
-        :value  => '',
-        :dir    => directory,
-      }}
+    it { is_expected.to compile.with_all_deps }
 
-      it 'should contain a property file' do
-          should contain_file(
-            "#{directory}/#{title}"
-          ).with({
-          'ensure'  => 'file',
-          })
-      end
-    end
-
-    describe 'when ensure is absent and the value is empty' do
-      let(:params) {{
-        :ensure => 'absent',
-        :value  => '',
-        :dir    => directory,
-      }}
-
-      it 'should not contain a property file' do
-          should contain_file(
-            "#{directory}/#{title}"
-          ).with({
-          'ensure'  => 'absent',
-          })
-      end
-    end
-
-    describe 'when ensure is absent and the value is a boolean' do
-      let(:params) {{
-        :ensure => 'absent',
-        :value  => false,
-        :dir    => directory,
-      }}
-
-      it 'should not contain a property file' do
-          should contain_file(
-            "#{directory}/?no-#{title}"
-          ).with({
-          'ensure'  => 'absent',
-          })
-      end
-    end
-
-    describe 'when ensure is absent and the value is numeric' do
-      let(:params) {{
-        :ensure => 'absent',
-        :value  => 123,
-        :dir    => directory,
-      }}
-
-      it 'should not contain a property file' do
-          should contain_file(
-            "#{directory}/#{title}"
-          ).with({
-          'ensure'  => 'absent',
-          })
-      end
-    end
-
-    describe 'when ensure is directory' do
-      let(:params) {{
-        :ensure => 'directory',
-        :value  => 'test',
-        :dir    => directory,
-      }}
-
-      it { should raise_error(/\$ensure must be .* not 'directory'/) }
+    it 'should remove a property file' do
+      is_expected.to contain_file("#{directory}/#{title}").with_ensure('absent')
     end
   end
+
+  describe 'when ensure is file and the value is empty' do
+    let(:params) do
+      {
+          :ensure => 'file',
+          :value => '',
+          :dir => directory,
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it 'should create the property file with an empty value' do
+      parameters = {
+          :ensure => 'present',
+          :content => "\n",
+      }
+      is_expected.to contain_file("#{directory}/#{title}").with(parameters)
+    end
+  end
+
+  describe 'when ensure is directory' do
+    let(:params) do
+      {
+          :ensure => 'directory',
+          :value => 'test',
+          :dir => directory,
+      }
+    end
+
+    it 'should fail with an error' do
+      expect do
+        is_expected.to compile.with_all_deps
+      end.to raise_error /ensure must be one of/
+    end
+  end
+
+  context 'file attributes' do
+    context 'default' do
+      let(:params) do
+        {
+            :ensure => 'present',
+            :value => 'test',
+            :dir => directory,
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_class('mesos::params') }
+
+      parameters = {
+          :owner => 'root',
+          :group => 'root',
+          :mode => '0644',
+      }
+
+      it { is_expected.to contain_file("#{directory}/#{title}").with(parameters) }
+
+      it { is_expected.not_to contain_mesos__property(title).with(parameters) }
+    end
+
+    context 'custom' do
+      let(:params) do
+        {
+            :ensure => 'present',
+            :value => 'test',
+            :owner => 'user',
+            :group => 'group',
+            :mode => '0640',
+            :dir => directory,
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      it { is_expected.to contain_class('mesos::params') }
+
+      parameters = {
+          :owner => 'user',
+          :group => 'group',
+          :mode => '0640',
+      }
+
+      it { is_expected.to contain_file("#{directory}/#{title}").with(parameters) }
+
+      it { is_expected.to contain_mesos__property(title).with(parameters) }
+    end
+  end
+
+  context 'when the property file is overridden' do
+    let(:params) do
+      {
+          :value => 'foo',
+          :file => 'some-other-property',
+          :dir => directory,
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it { is_expected.to contain_mesos__property(title) }
+
+    it do
+      parameters = {
+          :ensure => 'present',
+          :content => "foo\n",
+      }
+      is_expected.to contain_file("#{directory}/some-other-property").with(parameters)
+    end
+  end
+
+  context 'service notification' do
+    let(:params) do
+      {
+          :ensure => 'present',
+          :value => 'test',
+          :service => 'Service[my-service]',
+          :dir => directory,
+      }
+    end
+
+    it 'should fail with an error' do
+      expect do
+        is_expected.to compile.with_all_deps
+      end.to raise_error /service is deprecated and will be removed in the next major release/
+    end
+  end
+
 end

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe 'mesos::service', :type => :define do
   let(:title) { 'slave' }
 
+  before(:each) do
+    puppet_debug_override
+  end
+
   shared_examples 'mesos-service' do |family, os, codename|
     let(:facts) {{
       :osfamily => family,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 RSpec.configure do |c|
   c.treat_symbols_as_metadata_keys_with_true_values = true
   c.include PuppetlabsSpec::Files
-  c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+  c.hiera_config = File.join fixture_path, 'hiera', 'hiera.yaml'
 
   c.before :each do
     # Ensure that we don't accidentally cache facts and environment
@@ -23,7 +23,7 @@ RSpec.configure do |c|
     ENV.each_key {|k| @old_env[k] = ENV[k]}
 
     if ENV['STRICT_VARIABLES'] == 'yes'
-      Puppet.settings[:strict_variables]=true
+      Puppet.settings[:strict_variables] = true
     end
   end
   c.after :each do
@@ -31,7 +31,10 @@ RSpec.configure do |c|
   end
 end
 
-Puppet::Util::Log.level = :info
-Puppet::Util::Log.newdestination(:console)
+def puppet_debug_override
+  return unless ENV['SPEC_PUPPET_DEBUG']
+  Puppet::Util::Log.level = :debug
+  Puppet::Util::Log.newdestination(:console)
+end
 
 at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
* Add newline character to the end of a property value.
  It doesn't mess with values because options are used
  as the command line arguments by the shell
* Refactored property definition with the cleaner code.
  There is no need to treat numeric values differently,
  set default ensure, use pick functions and defaults
  from the params class.
* Rewrite property spec and some other fixes
* Add todo file