### PR TITLE
Install the package before managing the $conf_dir for slave

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -110,6 +110,7 @@ class mesos::slave (
     recurse => true,
     purge   => true,
     force   => true,
+    require => Class['::mesos::install'],
     notify  => Service['mesos-slave'], # when key is removed we want to reload the service
   }
 


### PR DESCRIPTION
Fix issue with rpmnew file

mesos-slave[23463]: Failed to load unknown flag 'work_dir.rpmnew'