### PR TITLE
Fixed the mesos_version variable check, which fails if the puppet ser…

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -146,10 +146,14 @@ class mesos::slave (
     $credentials_ensure = absent
   }
 
-  if ($::mesos_version != undef) and (versioncmp($::mesos_version, '0.28.0') >= 0)
-    and $service_provider != 'systemd' {
-    # otherwise rely on mesos-slave defaults
-      $systemd_support = {'systemd_enable_support' => false}
+  if defined('$::mesos_version') {
+    if ($::mesos_version != undef) and (versioncmp($::mesos_version, '0.28.0') >= 0)
+      and $service_provider != 'systemd' {
+      # otherwise rely on mesos-slave defaults
+        $systemd_support = {'systemd_enable_support' => false}
+    } else {
+      $systemd_support = {}
+    }
   } else {
     $systemd_support = {}
   }


### PR DESCRIPTION
Hi,

Fixed the $::mesos_version variable check, which fails if the puppet server has "strict_variables = true"
The failure is:
```
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Unknown variable: '::mesos_version'. (file: $MYPATH/mesos/manifests/slave.pp, line: 149, column: 7) on node $MYHOST
```
This failure is triggered before mesos is installed, which seems to populate this "fact".
After the mesos-master binary is avilable the issue is gone.
Unfortunately the installation through puppet never takes place, since with strict_variables enabled, the catalog compilation fails and no installation is attempted.

Kind Regards,
Atanas