### PR TITLE
Adds notifier from credentials and acls files to services

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -112,12 +112,14 @@ class mesos::master(
     ensure  => $acls_ensure,
     content => $acls_content,
     mode    => '0444',
+    notify  => Service['mesos-master'],
   }
 
   file { $credentials_file:
     ensure  => $credentials_ensure,
     content => $credentials_content,
     mode    => '0400',
+    notify  => Service['mesos-master'],
   }
 
   # work_dir can't be specified via options,

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -186,6 +186,7 @@ class mesos::slave (
     ensure  => $credentials_ensure,
     content => $credentials_content,
     mode    => '0400',
+    notify  => Service['mesos-slave'],
   }
 
   create_resources(mesos::property,


### PR DESCRIPTION
Hi!

This pull request adds notifiers from `credentials_file` and `acls_file` to services.

Determining whether authorization or authentication is enabled is done during the start of the service e.g., through the `--credentials` option.
Then, the service reads the corresponding files. For example, you can see the system call that took place when the `mesos-master` fires up.

```
6112  open("/etc/mesos/master-credentials", O_RDONLY|O_CLOEXEC) = 7
6112  ioctl(7, TCGETS, 0x7ffc30844c60)  = -1 ENOTTY (Inappropriate ioctl for device)
6112  read(7, "{\"credentials\":[{\"principal\":\"some-principal\",\"secret\":\"some-secret\"}]}", 4096) = 71
6112  read(7, "", 4025)                 = 0
6112  read(7, "", 4096)                 = 0
6112  close(7)                          = 0
```

I would expect that whenever there is a change/update to those files, the services is notified.